### PR TITLE
Upgrade the dependency on Easymock to 3.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -319,9 +319,9 @@ under the License.
         <version>2.2</version>
       </dependency>
       <dependency>
-        <groupId>easymock</groupId>
+        <groupId>org.easymock</groupId>
         <artifactId>easymock</artifactId>
-        <version>1.2_Java1.5</version>
+        <version>3.2</version>
         <scope>test</scope>
       </dependency>
 

--- a/wagon-provider-api/pom.xml
+++ b/wagon-provider-api/pom.xml
@@ -37,7 +37,7 @@ under the License.
       <artifactId>plexus-utils</artifactId>
     </dependency>
     <dependency>
-      <groupId>easymock</groupId>
+      <groupId>org.easymock</groupId>
       <artifactId>easymock</artifactId>
       <scope>test</scope>
     </dependency>

--- a/wagon-provider-api/src/test/java/org/apache/maven/wagon/StreamWagonTest.java
+++ b/wagon-provider-api/src/test/java/org/apache/maven/wagon/StreamWagonTest.java
@@ -36,7 +36,8 @@ import org.codehaus.plexus.util.FileUtils;
 import org.codehaus.plexus.util.IOUtil;
 import org.codehaus.plexus.util.StringInputStream;
 import org.codehaus.plexus.util.StringOutputStream;
-import org.easymock.MockControl;
+
+import static org.easymock.EasyMock.*;
 
 public class StreamWagonTest
     extends TestCase
@@ -78,15 +79,13 @@ public class StreamWagonTest
             }
         };
 
-        MockControl control = MockControl.createControl( TransferListener.class );
-        TransferListener listener = (TransferListener) control.getMock();
-        listener.transferInitiated( null );
-        control.setMatcher( MockControl.ALWAYS_MATCHER );
+        TransferListener listener = createMock( TransferListener.class );
+        listener.transferInitiated( anyObject( TransferEvent.class ) );
         TransferEvent transferEvent =
             new TransferEvent( wagon, new Resource( "resource" ), new TransferFailedException( "" ),
                                TransferEvent.REQUEST_GET );
         listener.transferError( transferEvent );
-        control.replay();
+        replay( listener );
 
         wagon.connect( repository );
         wagon.addTransferListener( listener );
@@ -104,7 +103,7 @@ public class StreamWagonTest
             wagon.disconnect();
         }
 
-        control.verify();
+        verify( listener );
     }
 
     public void testNullOutputStream()
@@ -118,15 +117,13 @@ public class StreamWagonTest
             }
         };
 
-        MockControl control = MockControl.createControl( TransferListener.class );
-        TransferListener listener = (TransferListener) control.getMock();
-        listener.transferInitiated( null );
-        control.setMatcher( MockControl.ALWAYS_MATCHER );
+        TransferListener listener = createMock( TransferListener.class );
+        listener.transferInitiated( anyObject( TransferEvent.class ) );
         TransferEvent transferEvent =
             new TransferEvent( wagon, new Resource( "resource" ), new TransferFailedException( "" ),
                                TransferEvent.REQUEST_PUT );
         listener.transferError( transferEvent );
-        control.replay();
+        replay( listener );
 
         wagon.connect( repository );
         wagon.addTransferListener( listener );
@@ -144,7 +141,7 @@ public class StreamWagonTest
             wagon.disconnect();
         }
 
-        control.verify();
+        verify( listener );
     }
 
     public void testTransferFailedExceptionOnInput()
@@ -173,15 +170,13 @@ public class StreamWagonTest
             }
         };
 
-        MockControl control = MockControl.createControl( TransferListener.class );
-        TransferListener listener = (TransferListener) control.getMock();
-        listener.transferInitiated( null );
-        control.setMatcher( MockControl.ALWAYS_MATCHER );
+        TransferListener listener = createMock( TransferListener.class );
+        listener.transferInitiated( anyObject( TransferEvent.class ) );
         TransferEvent transferEvent =
             new TransferEvent( wagon, new Resource( "resource" ), new TransferFailedException( "" ),
                                TransferEvent.REQUEST_PUT );
         listener.transferError( transferEvent );
-        control.replay();
+        replay( listener );
 
         wagon.connect( repository );
         wagon.addTransferListener( listener );
@@ -197,7 +192,7 @@ public class StreamWagonTest
         finally
         {
             wagon.disconnect();
-            control.verify();
+            verify( listener );
         }
     }
 
@@ -253,14 +248,12 @@ public class StreamWagonTest
             }
         };
 
-        MockControl control = MockControl.createControl( TransferListener.class );
-        TransferListener listener = (TransferListener) control.getMock();
-        listener.transferInitiated( null );
-        control.setMatcher( MockControl.ALWAYS_MATCHER );
+        TransferListener listener = createMock( TransferListener.class );
+        listener.transferInitiated( anyObject( TransferEvent.class ) );
         TransferEvent transferEvent =
             new TransferEvent( wagon, new Resource( "resource" ), exception, TransferEvent.REQUEST_GET );
         listener.transferError( transferEvent );
-        control.replay();
+        replay( listener );
 
         wagon.connect( repository );
         wagon.addTransferListener( listener );
@@ -272,7 +265,7 @@ public class StreamWagonTest
         finally
         {
             wagon.disconnect();
-            control.verify();
+            verify( listener );
         }
     }
 

--- a/wagon-provider-api/src/test/java/org/apache/maven/wagon/events/SessionEventSupportTest.java
+++ b/wagon-provider-api/src/test/java/org/apache/maven/wagon/events/SessionEventSupportTest.java
@@ -22,7 +22,7 @@ package org.apache.maven.wagon.events;
 import junit.framework.TestCase;
 
 import org.apache.maven.wagon.Wagon;
-import org.easymock.MockControl;
+import org.easymock.EasyMock;
 
 /**
  * @author <a href="michal.maczka@dimatics.com">Michal Maczka</a>
@@ -34,8 +34,6 @@ public class SessionEventSupportTest
 
     private SessionEventSupport eventSupport;
 
-    private MockControl wagonMockControl;
-    
     private Wagon wagon;
 
     /**
@@ -49,9 +47,7 @@ public class SessionEventSupportTest
         eventSupport = new SessionEventSupport();
         
         // TODO: actually test it gets called?
-        wagonMockControl = MockControl.createControl( Wagon.class );
-        
-        wagon = (Wagon) wagonMockControl.getMock();
+        wagon = EasyMock.createMock( Wagon.class );
     }
 
     public void testSessionListenerRegistration()

--- a/wagon-provider-api/src/test/java/org/apache/maven/wagon/events/SessionEventTest.java
+++ b/wagon-provider-api/src/test/java/org/apache/maven/wagon/events/SessionEventTest.java
@@ -24,7 +24,7 @@ import org.apache.maven.wagon.ConnectionException;
 import org.apache.maven.wagon.Wagon;
 import org.apache.maven.wagon.authentication.AuthenticationException;
 import org.apache.maven.wagon.repository.Repository;
-import org.easymock.MockControl;
+import org.easymock.EasyMock;
 
 /**
  * @author <a href="michal.maczka@dimatics.com">Michal Maczka</a>
@@ -41,7 +41,7 @@ public class SessionEventTest
         throws ConnectionException, AuthenticationException
     {
 
-        final Wagon wagon = (Wagon) MockControl.createControl( Wagon.class ).getMock();
+        final Wagon wagon = EasyMock.createMock( Wagon.class );
         final Repository repo = new Repository();
 
         wagon.connect( repo );

--- a/wagon-provider-api/src/test/java/org/apache/maven/wagon/events/TransferEventSupportTest.java
+++ b/wagon-provider-api/src/test/java/org/apache/maven/wagon/events/TransferEventSupportTest.java
@@ -21,7 +21,7 @@ package org.apache.maven.wagon.events;
 
 import junit.framework.TestCase;
 import org.apache.maven.wagon.Wagon;
-import org.easymock.MockControl;
+import org.easymock.EasyMock;
 
 /**
  * @author <a href="michal.maczka@dimatics.com">Michal Maczka</a>
@@ -31,8 +31,6 @@ public class TransferEventSupportTest
 {
     private TransferEventSupport eventSupport;
 
-    private MockControl wagonMockControl;
-    
     private Wagon wagon;
 
     /**
@@ -46,9 +44,7 @@ public class TransferEventSupportTest
         eventSupport = new TransferEventSupport();
         
         // TODO: actually test it gets called?
-        wagonMockControl = MockControl.createControl( Wagon.class );
-        
-        wagon = (Wagon) wagonMockControl.getMock();
+        wagon = EasyMock.createMock( Wagon.class );
     }
 
     public void testTransferListenerRegistration()

--- a/wagon-provider-api/src/test/java/org/apache/maven/wagon/events/TransferEventTest.java
+++ b/wagon-provider-api/src/test/java/org/apache/maven/wagon/events/TransferEventTest.java
@@ -25,7 +25,7 @@ import org.apache.maven.wagon.Wagon;
 import org.apache.maven.wagon.authentication.AuthenticationException;
 import org.apache.maven.wagon.repository.Repository;
 import org.apache.maven.wagon.resource.Resource;
-import org.easymock.MockControl;
+import org.easymock.EasyMock;
 
 /**
  * @author <a href="michal.maczka@dimatics.com">Michal Maczka</a>
@@ -41,7 +41,7 @@ public class TransferEventTest
     public void testTransferEventProperties()
         throws ConnectionException, AuthenticationException
     {
-        final Wagon wagon = (Wagon) MockControl.createControl( Wagon.class ).getMock();
+        final Wagon wagon = EasyMock.createMock( Wagon.class );
 
         final Repository repo = new Repository();
 

--- a/wagon-provider-test/pom.xml
+++ b/wagon-provider-test/pom.xml
@@ -46,7 +46,7 @@ under the License.
       <scope>compile</scope>
     </dependency>
     <dependency>
-      <groupId>easymock</groupId>
+      <groupId>org.easymock</groupId>
       <artifactId>easymock</artifactId>
       <scope>compile</scope>
     </dependency>

--- a/wagon-provider-test/src/main/java/org/apache/maven/wagon/StreamingWagonTestCase.java
+++ b/wagon-provider-test/src/main/java/org/apache/maven/wagon/StreamingWagonTestCase.java
@@ -140,7 +140,7 @@ public abstract class StreamingWagonTestCase
     {
         StreamingWagon wagon = (StreamingWagon) getWagon();
 
-        ProgressArgumentMatcher progressArgumentMatcher = setupGetIfNewerTest( wagon, expectedResult, expectedSize );
+        ProgressAnswer progressAnswer = setupGetIfNewerTest( wagon, expectedResult, expectedSize );
 
         connectWagon( wagon );
 
@@ -158,7 +158,7 @@ public abstract class StreamingWagonTestCase
 
         disconnectWagon( wagon );
 
-        assertGetIfNewerTest( progressArgumentMatcher, expectedResult, expectedSize );
+        assertGetIfNewerTest( progressAnswer, expectedResult, expectedSize );
 
         tearDownWagonTestingFixtures();
     }
@@ -241,7 +241,7 @@ public abstract class StreamingWagonTestCase
 
         StreamingWagon wagon = (StreamingWagon) getWagon();
 
-        ProgressArgumentMatcher progressArgumentMatcher = replayMockForPut( resource, content, wagon );
+        ProgressAnswer progressAnswer = replayMockForPut( resource, content, wagon );
 
         message( "Putting test artifact: " + resource + " into test repository " + testRepository );
 
@@ -265,7 +265,7 @@ public abstract class StreamingWagonTestCase
 
         disconnectWagon( wagon );
 
-        verifyMock( progressArgumentMatcher, content.length() );
+        verifyMock( progressAnswer, content.length() );
         return content.length();
     }
 
@@ -277,7 +277,7 @@ public abstract class StreamingWagonTestCase
 
         StreamingWagon wagon = (StreamingWagon) getWagon();
 
-        ProgressArgumentMatcher progressArgumentMatcher = replaceMockForGet( wagon, expectedSize );
+        ProgressAnswer progressAnswer = replaceMockForGet( wagon, expectedSize );
 
         message( "Getting test artifact from test repository " + testRepository );
 
@@ -301,6 +301,6 @@ public abstract class StreamingWagonTestCase
 
         disconnectWagon( wagon );
 
-        verifyMock( progressArgumentMatcher, expectedSize );
+        verifyMock( progressAnswer, expectedSize );
     }
 }


### PR DESCRIPTION
Hi,

Wagon depends on a rather old version of EasyMock. The class `MockControl` used in several tests has been deprecated in EasyMock 2.0 (2005) and eventually removed in EasyMock 3.0 (2010).

Could you please apply this patch upgrading the tests to the latest API ?

Thank you.
