### PR TITLE
[WAGON-418] Adding commons-logging dependency back to wagon-webdav-jackrabbit

### DIFF
--- a/wagon-providers/wagon-webdav-jackrabbit/pom.xml
+++ b/wagon-providers/wagon-webdav-jackrabbit/pom.xml
@@ -86,6 +86,16 @@ under the License.
         </exclusion>
       </exclusions>
     </dependency>
+    
+    <!--
+    This dependency is here to upgrade to a version of commons-logging that is
+    newer than the one that comes transitively from commons-httpclient above.
+    -->
+    <dependency>
+       <groupId>commons-logging</groupId>
+       <artifactId>commons-logging</artifactId>
+       <version>1.1.1</version>
+    </dependency>
 
     <!-- Test dependencies -->
     <dependency>


### PR DESCRIPTION
Re-adding the dependency that was supposed to be moved from `wagon-http-shared` so `common-httpclient` can be used properly.
