### PR TITLE
Prevent fingerprints loss in known_hosts

### DIFF
--- a/wagon-providers/wagon-ssh-common/src/main/java/org/apache/maven/wagon/providers/ssh/knownhost/AbstractKnownHostsProvider.java
+++ b/wagon-providers/wagon-ssh-common/src/main/java/org/apache/maven/wagon/providers/ssh/knownhost/AbstractKnownHostsProvider.java
@@ -66,5 +66,8 @@ public abstract class AbstractKnownHostsProvider
     {
     }
     
-    
+    public void addKnownHost( KnownHostEntry knownHost )
+        throws IOException
+    {
+    }
 }

--- a/wagon-providers/wagon-ssh-common/src/main/java/org/apache/maven/wagon/providers/ssh/knownhost/FileKnownHostsProvider.java
+++ b/wagon-providers/wagon-ssh-common/src/main/java/org/apache/maven/wagon/providers/ssh/knownhost/FileKnownHostsProvider.java
@@ -81,6 +81,16 @@ public class FileKnownHostsProvider
         }
     }
     
+    public void addKnownHost( KnownHostEntry knownHostEntry )
+        throws IOException
+    {
+        if( !this.knownHosts.contains( knownHostEntry ) )
+        {
+            String knownHost = knownHostEntry.getHostName()+" "+knownHostEntry.getKeyType()+" "+knownHostEntry.getKeyValue()+"\n";
+            FileUtils.fileAppend( file.getAbsolutePath(), knownHost );
+        }
+    }
+    
     public File getFile()
     {
         return file;

--- a/wagon-providers/wagon-ssh-common/src/main/java/org/apache/maven/wagon/providers/ssh/knownhost/KnownHostsProvider.java
+++ b/wagon-providers/wagon-ssh-common/src/main/java/org/apache/maven/wagon/providers/ssh/knownhost/KnownHostsProvider.java
@@ -33,6 +33,9 @@ public interface KnownHostsProvider
 
     void storeKnownHosts( String contents )
         throws IOException;
+    
+    void addKnownHost( KnownHostEntry knownHost )
+        throws IOException;
 
     void setHostKeyChecking( String hostKeyChecking );
 

--- a/wagon-providers/wagon-ssh/src/main/java/org/apache/maven/wagon/providers/ssh/jsch/AbstractJschWagon.java
+++ b/wagon-providers/wagon-ssh/src/main/java/org/apache/maven/wagon/providers/ssh/jsch/AbstractJschWagon.java
@@ -25,8 +25,6 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
-import java.io.PrintWriter;
-import java.io.StringWriter;
 import java.util.List;
 import java.util.Properties;
 
@@ -48,6 +46,7 @@ import org.apache.maven.wagon.providers.ssh.interactive.InteractiveUserInfo;
 import org.apache.maven.wagon.providers.ssh.interactive.NullInteractiveUserInfo;
 import org.apache.maven.wagon.providers.ssh.jsch.interactive.UserInfoUIKeyboardInteractiveProxy;
 import org.apache.maven.wagon.providers.ssh.knownhost.KnownHostChangedException;
+import org.apache.maven.wagon.providers.ssh.knownhost.KnownHostEntry;
 import org.apache.maven.wagon.providers.ssh.knownhost.KnownHostsProvider;
 import org.apache.maven.wagon.providers.ssh.knownhost.UnknownHostException;
 import org.apache.maven.wagon.proxy.ProxyInfo;
@@ -55,10 +54,6 @@ import org.apache.maven.wagon.resource.Resource;
 import org.codehaus.plexus.util.IOUtil;
 import org.codehaus.plexus.util.StringInputStream;
 
-import com.jcraft.jsch.agentproxy.AgentProxyException;
-import com.jcraft.jsch.agentproxy.Connector;
-import com.jcraft.jsch.agentproxy.ConnectorFactory;
-import com.jcraft.jsch.agentproxy.RemoteIdentityRepository;
 import com.jcraft.jsch.ChannelExec;
 import com.jcraft.jsch.HostKey;
 import com.jcraft.jsch.HostKeyRepository;
@@ -71,6 +66,10 @@ import com.jcraft.jsch.ProxySOCKS5;
 import com.jcraft.jsch.Session;
 import com.jcraft.jsch.UIKeyboardInteractive;
 import com.jcraft.jsch.UserInfo;
+import com.jcraft.jsch.agentproxy.AgentProxyException;
+import com.jcraft.jsch.agentproxy.Connector;
+import com.jcraft.jsch.agentproxy.ConnectorFactory;
+import com.jcraft.jsch.agentproxy.RemoteIdentityRepository;
 
 /**
  * AbstractJschWagon
@@ -247,24 +246,9 @@ public abstract class AbstractJschWagon
 
         session.setUserInfo( ui );
 
-        StringWriter stringWriter = new StringWriter();
         try
         {
             session.connect();
-
-            if ( getKnownHostsProvider() != null )
-            {
-                PrintWriter w = new PrintWriter( stringWriter );
-
-                HostKeyRepository hkr = sch.getHostKeyRepository();
-                HostKey[] keys = hkr.getHostKey();
-
-                for ( int i = 0; keys != null && i < keys.length; i++ )
-                {
-                    HostKey key = keys[i];
-                    w.println( key.getHost() + " " + key.getType() + " " + key.getKey() );
-                }
-            }
         }
         catch ( JSchException e )
         {
@@ -282,17 +266,27 @@ public abstract class AbstractJschWagon
             }
         }
 
-        try
+        if ( getKnownHostsProvider() != null )
         {
-            getKnownHostsProvider().storeKnownHosts( stringWriter.toString() );
+            HostKeyRepository hkr = sch.getHostKeyRepository();
+            
+            HostKey[] hk = hkr.getHostKey(host, null);
+            try
+            {
+                for (HostKey hostKey : hk) {
+                    KnownHostEntry knownHostEntry = new KnownHostEntry( hostKey.getHost(), hostKey.getType(), hostKey.getKey() );
+                    getKnownHostsProvider().addKnownHost( knownHostEntry );
+                }
+            }
+            catch ( IOException e )
+            {
+                closeConnection();
+                
+                throw new AuthenticationException(
+                        "Connection aborted - failed to write to known_hosts. Reason: " + e.getMessage(), e );
+            }
         }
-        catch ( IOException e )
-        {
-            closeConnection();
-
-            throw new AuthenticationException(
-                "Connection aborted - failed to write to known_hosts. Reason: " + e.getMessage(), e );
-        }
+        
     }
 
     public void closeConnection()

--- a/wagon-providers/wagon-ssh/src/test/java/org/apache/maven/wagon/providers/ssh/jsch/EmbeddedScpWagonTest.java
+++ b/wagon-providers/wagon-ssh/src/test/java/org/apache/maven/wagon/providers/ssh/jsch/EmbeddedScpWagonTest.java
@@ -21,6 +21,7 @@ package org.apache.maven.wagon.providers.ssh.jsch;
 
 import org.apache.maven.wagon.Wagon;
 import org.apache.maven.wagon.providers.ssh.AbstractEmbeddedScpWagonTest;
+import org.apache.maven.wagon.providers.ssh.knownhost.KnownHostEntry;
 import org.apache.maven.wagon.providers.ssh.knownhost.KnownHostsProvider;
 
 import java.io.IOException;
@@ -45,6 +46,11 @@ public class EmbeddedScpWagonTest
                 throws IOException
             {
 
+            }
+
+            public void addKnownHost( KnownHostEntry knownHost )
+                throws IOException
+            {
             }
 
             public void setHostKeyChecking( String hostKeyChecking )

--- a/wagon-providers/wagon-ssh/src/test/java/org/apache/maven/wagon/providers/ssh/jsch/EmbeddedScpWagonWithKeyTest.java
+++ b/wagon-providers/wagon-ssh/src/test/java/org/apache/maven/wagon/providers/ssh/jsch/EmbeddedScpWagonWithKeyTest.java
@@ -22,6 +22,7 @@ package org.apache.maven.wagon.providers.ssh.jsch;
 import org.apache.maven.wagon.Wagon;
 import org.apache.maven.wagon.authentication.AuthenticationInfo;
 import org.apache.maven.wagon.providers.ssh.AbstractEmbeddedScpWagonWithKeyTest;
+import org.apache.maven.wagon.providers.ssh.knownhost.KnownHostEntry;
 import org.apache.maven.wagon.providers.ssh.knownhost.KnownHostsProvider;
 
 import java.io.File;
@@ -48,6 +49,11 @@ public class EmbeddedScpWagonWithKeyTest
                 throws IOException
             {
 
+            }
+
+            public void addKnownHost( KnownHostEntry knownHost )
+                throws IOException
+            {
             }
 
             public void setHostKeyChecking( String hostKeyChecking )


### PR DESCRIPTION
Currently, when adding new fingerprints the whole known_hosts file is rewritten from the loaded fingerprints.
But only fingerprints with a compatible algorithm (from jsch point of view) are kept: for example, all "ecdsa-sha2-nistp256" are lost!

Hence this pull request that appends the new fingerprint in the known_hosts file (without modifying the rest of the file) and keeps unknown fingerprints with unknown algorithms.