### PR TITLE
[WAGON-449] Recreate http-wagon client when connection manager is changed

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -128,6 +128,9 @@ under the License.
     <contributor>
       <name>Grzegorz Grzybek</name>
     </contributor>
+    <contributor>
+      <name>Jean Niklas L'orange</name>
+    </contributor>
   </contributors>
 
   <mailingLists>

--- a/wagon-providers/wagon-http/src/main/java/org/apache/maven/wagon/providers/http/AbstractHttpClientWagon.java
+++ b/wagon-providers/wagon-http/src/main/java/org/apache/maven/wagon/providers/http/AbstractHttpClientWagon.java
@@ -364,7 +364,7 @@ public abstract class AbstractHttpClientWagon
         return connManager;
     }
 
-    private static final CloseableHttpClient CLIENT = createClient();
+    private static CloseableHttpClient httpClient = createClient();
 
     private static CloseableHttpClient createClient()
     {
@@ -481,6 +481,7 @@ public abstract class AbstractHttpClientWagon
         PoolingHttpClientConnectionManager poolingHttpClientConnectionManager )
     {
         httpClientConnectionManager = poolingHttpClientConnectionManager;
+        httpClient = createClient();
     }
 
     public void put( File source, String resourceName )
@@ -829,7 +830,7 @@ public abstract class AbstractHttpClientWagon
             }
         }
 
-        return CLIENT.execute( httpMethod, localContext );
+        return httpClient.execute( httpMethod, localContext );
     }
 
     protected void setHeaders( HttpUriRequest method )


### PR DESCRIPTION
Hi there,

This is a fix for the bug report [WAGON-449](https://issues.apache.org/jira/browse/WAGON-449). It changes the CLIENT field to a nonfinal field so that it can be updated, and then recreates it whenever `setPoolingHttpClientConnectionManager` is set. This means that the new client will actually be generated from the newly set connection manager.

As this this includes setting CLIENT to a nonfinal field, its name is changed to httpClient to satisfy naming conventions.

I have tried to make this pull request as close to what seems to be the convention this project uses, but I may have missed things as I am not mainly a Java programmer nor uses Maven extensively. Please feel free to mention anything that I may have missed or would make it easier for you folks to apply this patch.