### PR TITLE
[WAGON-451] Accept NO CONTENT in resourceExists

### DIFF
--- a/wagon-providers/wagon-http-lightweight/src/main/java/org/apache/maven/wagon/providers/http/LightweightHttpWagon.java
+++ b/wagon-providers/wagon-http-lightweight/src/main/java/org/apache/maven/wagon/providers/http/LightweightHttpWagon.java
@@ -392,7 +392,9 @@ public class LightweightHttpWagon
 
             switch ( statusCode )
             {
-                case HttpURLConnection.HTTP_OK:
+                case HttpURLConnection.HTTP_OK: // 200
+                case HttpURLConnection.HTTP_NO_CONTENT: // 204
+                case HttpURLConnection.HTTP_NOT_MODIFIED: // 304
                     return true;
 
                 case HttpURLConnection.HTTP_FORBIDDEN:

--- a/wagon-providers/wagon-http/src/main/java/org/apache/maven/wagon/providers/http/AbstractHttpClientWagon.java
+++ b/wagon-providers/wagon-http/src/main/java/org/apache/maven/wagon/providers/http/AbstractHttpClientWagon.java
@@ -698,10 +698,9 @@ public abstract class AbstractHttpClientWagon
                 boolean result;
                 switch ( statusCode )
                 {
-                    case HttpStatus.SC_OK:
-                        result = true;
-                        break;
-                    case HttpStatus.SC_NOT_MODIFIED:
+                    case HttpStatus.SC_OK: // 200
+                    case HttpStatus.SC_NO_CONTENT: // 204
+                    case HttpStatus.SC_NOT_MODIFIED: // 304
                         result = true;
                         break;
                     case HttpStatus.SC_FORBIDDEN:


### PR DESCRIPTION
Some maven repositories may respond with 204 NO CONTENT instead of 200 OK when sending in HTTP HEAD requests. This throws an exception in wagon-http and wagon-http-lightweight.

This patch makes 204 NO CONTENT responses from HTTP HEAD requests in wagon-http and wagon-http-lightweight return true in `resourceExists`, instead of throwing an exception.

The patch also adds makes wagon-http-lightweight accept 304 NOT MODIFIED, to make it consistent with the wagon-http implementation.