### PR TITLE
Add support for detecting and using of KiTTY's klink.exe and kscp.exe

### DIFF
--- a/wagon-providers/wagon-ssh-external/src/main/java/org/apache/maven/wagon/providers/ssh/external/ScpExternalWagon.java
+++ b/wagon-providers/wagon-ssh-external/src/main/java/org/apache/maven/wagon/providers/ssh/external/ScpExternalWagon.java
@@ -217,7 +217,8 @@ public class ScpExternalWagon
 
     protected boolean isPuTTY()
     {
-        return sshExecutable.toLowerCase( Locale.ENGLISH ).contains( "plink" );
+        String exe = sshExecutable.toLowerCase( Locale.ENGLISH );
+        return exe.contains( "plink" ) || exe.contains( "klink" );
     }
 
     private Commandline createBaseCommandLine( boolean putty, String executable, File privateKey )
@@ -336,7 +337,8 @@ public class ScpExternalWagon
 
     boolean isPuTTYSCP()
     {
-        return scpExecutable.toLowerCase( Locale.ENGLISH ).contains( "pscp" );
+        String exe = scpExecutable.toLowerCase( Locale.ENGLISH );
+        return exe.contains( "pscp" ) || exe.contains( "kscp" );
     }
 
     private String normalizeResource( Resource resource )


### PR DESCRIPTION
KiTTY is a PuTTY fork available at http://www.9bis.net/kitty/

When using KiTTY's klink.exe/kscp.exe instead of PuTTY's plink.exe/pscp.exe, the ScpExternalWagon implementation passes the command line arguments "-o BatchMode yes" to these executables which fail with "unknown option -o".

This patch changes the ScpExternalWagon class to treat KiTTY executables like PuTTY executables.
