### PR TITLE
[WAGON-467] Allow customisation of some SSH options

### DIFF
--- a/wagon-providers/wagon-ssh/src/main/java/org/apache/maven/wagon/providers/ssh/jsch/AbstractJschWagon.java
+++ b/wagon-providers/wagon-ssh/src/main/java/org/apache/maven/wagon/providers/ssh/jsch/AbstractJschWagon.java
@@ -81,6 +81,8 @@ public abstract class AbstractJschWagon
 
     protected Session session;
 
+    private String strictHostKeyChecking;
+
     /**
      * @plexus.requirement role-hint="file"
      */
@@ -90,6 +92,11 @@ public abstract class AbstractJschWagon
      * @plexus.requirement
      */
     private volatile InteractiveUserInfo interactiveUserInfo;
+
+    /**
+     * @plexus.configuration default-value="gssapi-with-mic,publickey,password,keyboard-interactive"
+     */
+    private volatile String preferredAuthentications;
 
     /**
      * @plexus.requirement
@@ -235,12 +242,16 @@ public abstract class AbstractJschWagon
             {
                 // continue without known_hosts
             }
-            config.setProperty( "StrictHostKeyChecking", getKnownHostsProvider().getHostKeyChecking() );
+            if ( strictHostKeyChecking == null )
+            {
+                strictHostKeyChecking = getKnownHostsProvider().getHostKeyChecking();
+            }
+            config.setProperty( "StrictHostKeyChecking", strictHostKeyChecking );
         }
 
         if ( authenticationInfo.getPassword() != null )
         {
-            config.setProperty( "PreferredAuthentications", "gssapi-with-mic,publickey,password,keyboard-interactive" );
+            config.setProperty( "PreferredAuthentications", preferredAuthentications );
         }
 
         config.setProperty( "BatchMode", interactive ? "no" : "yes" );
@@ -446,5 +457,25 @@ public abstract class AbstractJschWagon
     public void setUIKeyboardInteractive( UIKeyboardInteractive uIKeyboardInteractive )
     {
         this.uIKeyboardInteractive = uIKeyboardInteractive;
+    }
+
+    public String getPreferredAuthentications()
+    {
+        return preferredAuthentications;
+    }
+
+    public void setPreferredAuthentications( String preferredAuthentications )
+    {
+        this.preferredAuthentications = preferredAuthentications;
+    }
+
+    public String getStrictHostKeyChecking()
+    {
+        return strictHostKeyChecking;
+    }
+
+    public void setStrictHostKeyChecking( String strictHostKeyChecking )
+    {
+        this.strictHostKeyChecking = strictHostKeyChecking;
     }
 }


### PR DESCRIPTION
This commit add StrictHostKeyChecking and PreferredAuthentications custom fields that together allow you to perform, the command scp enough to remove any user interaction (username, password and add host key to know_hosts file).