### PR TITLE
[WAGON-458] FTPSClient for Wagon

### DIFF
--- a/wagon-providers/wagon-ftp/pom.xml
+++ b/wagon-providers/wagon-ftp/pom.xml
@@ -37,7 +37,7 @@ under the License.
     <dependency>
       <groupId>commons-net</groupId>
       <artifactId>commons-net</artifactId>
-      <version>3.1</version>
+      <version>3.5</version>
     </dependency>
 
     <dependency>

--- a/wagon-providers/wagon-ftp/src/main/java/org/apache/maven/wagon/providers/ftp/FtpWagon.java
+++ b/wagon-providers/wagon-ftp/src/main/java/org/apache/maven/wagon/providers/ftp/FtpWagon.java
@@ -112,7 +112,7 @@ public class FtpWagon
 
         String host = getRepository().getHost();
 
-        ftp = new FTPClient();
+        ftp = createClient();
         ftp.setDefaultTimeout( getTimeout() );
         ftp.setDataTimeout( getTimeout() );
         ftp.setControlEncoding( getControlEncoding() );
@@ -185,6 +185,11 @@ public class FtpWagon
         {
             throw new ConnectionException( "Cannot login to remote system", e );
         }
+    }
+
+    protected FTPClient createClient()
+    {
+        return new FTPClient();
     }
 
     protected void firePutCompleted( Resource resource, File file )

--- a/wagon-providers/wagon-ftp/src/main/java/org/apache/maven/wagon/providers/ftp/FtpsWagon.java
+++ b/wagon-providers/wagon-ftp/src/main/java/org/apache/maven/wagon/providers/ftp/FtpsWagon.java
@@ -1,0 +1,64 @@
+package org.apache.maven.wagon.providers.ftp;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import org.apache.commons.net.ftp.FTPClient;
+import org.apache.commons.net.ftp.FTPSClient;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * FtpsWagon
+ *
+ *
+ * @plexus.component role="org.apache.maven.wagon.Wagon"
+ * role-hint="ftps"
+ * instantiation-strategy="per-lookup"
+ */
+public class FtpsWagon
+    extends FtpWagon
+{
+    private static final Logger LOG = LoggerFactory.getLogger( FtpsWagon.class );
+
+    /**
+     * @plexus.configuration default-value="TLS"
+     */
+    private String securityProtocol = "TLS";
+
+    /**
+     * @plexus.configuration default-value="false"
+     */
+    private boolean implicit = false;
+
+    /**
+     * @plexus.configuration default-value="true"
+     */
+    private boolean endpointChecking = true;
+
+    @Override
+    protected FTPClient createClient()
+    {
+        LOG.debug( "Creating secure FTP client. Protocol: [{}], implicit mode: [{}], endpoint checking: [{}].",
+                securityProtocol, implicit, endpointChecking );
+        FTPSClient client = new FTPSClient( securityProtocol, implicit );
+        client.setEndpointCheckingEnabled( endpointChecking );
+        return client;
+    }
+}

--- a/wagon-providers/wagon-ftp/src/site/apt/index.apt
+++ b/wagon-providers/wagon-ftp/src/site/apt/index.apt
@@ -39,3 +39,64 @@ Features
  * Get files from FTP Server
 
  * Deploy files to FTP server
+
+Configuration
+
+ * <<<passiveMode>>> default: <<true>>
+
+ * <<<controlEncoding>>> default: <<"ISO-8859-1">>,
+ set from <<<org.apache.commons.net.ftp.FTP.DEFAULT_CONTROL_ENCODING>>>
+
+ * <<<securityProtocol>>> default: <<TLS>>, FTPS security protocol, TLS or SSL
+
+ * <<<implicit>>> default: <<false>>
+
+ * <<<endpointChecking>>> default: <<true>>
+
+Sample Configuration
+
+* pom.xml
+
+---------------------------------------------
+<project>
+    ...
+    <distributionManagement>
+        ...
+        <site>
+            <id>ftp.server.id</id>
+            <!--<url>ftp://ftp.example.com</url>-->
+            <url>ftps://secure.example.com</url>
+        </site>
+    </distributionManagement>
+    ...
+    <build>
+        <extensions>
+            <extension>
+                <groupId>org.apache.maven.wagon</groupId>
+                <artifactId>wagon-ftp</artifactId>
+            </extension>
+        </extensions>
+        ...
+    </build>
+    ...
+</project>
+---------------------------------------------
+
+* settings.xml
+
+---------------------------------------------
+<settings>
+    ...
+    <servers>
+        ...
+        <server>
+            <id>ftp.server.id</id>
+            <username>username</username>
+            <password>password</password>
+            <configuration>
+                <endpointChecking>false</endpointChecking>
+            </configuration>
+        </server>
+    </servers>
+<settings>
+---------------------------------------------


### PR DESCRIPTION
I've tested deploying artifacts to a FTPS server with `endpointChecking=false`.
This pull request still needs some testing against secure FTP server.
See also https://issues.apache.org/jira/browse/WAGON-458.

Inspired by pull requests:

* https://github.com/apache/maven-wagon/pull/24
* https://github.com/apache/maven-wagon/pull/22

After changes the configuration could look as follows:

**pom.xml**

```
<project>
    ...
    <distributionManagement>
        ...
        <site>
            <id>ftp.server.id</id>
            <url>ftps://secure.example.com</url>
        </site>
    </distributionManagement>
    ...
</project>
```

**settings.xml**

```
<settings>
    ...
    <servers>
        ...
        <server>
            <id>ftp.server.id</id>
            <username>username</username>
            <password>password</password>
            <configuration>
                <endpointChecking>false</endpointChecking>
            </configuration>
        </server>
    </servers>
<settings>
```
