### PR TITLE
[WAGON-469] wagon-http does not enable Expect-Continue by default

### DIFF
--- a/wagon-providers/wagon-http/src/main/java/org/apache/maven/wagon/providers/http/AbstractHttpClientWagon.java
+++ b/wagon-providers/wagon-http/src/main/java/org/apache/maven/wagon/providers/http/AbstractHttpClientWagon.java
@@ -786,6 +786,10 @@ public abstract class AbstractHttpClientWagon
         else
         {
             requestConfigBuilder.setSocketTimeout( getReadTimeout() );
+            if ( httpMethod instanceof HttpPut )
+            {
+                requestConfigBuilder.setExpectContinueEnabled( true );
+            }
         }
 
         localContext.setRequestConfig( requestConfigBuilder.build() );

--- a/wagon-providers/wagon-http/src/main/java/org/apache/maven/wagon/providers/http/HttpConfiguration.java
+++ b/wagon-providers/wagon-http/src/main/java/org/apache/maven/wagon/providers/http/HttpConfiguration.java
@@ -23,7 +23,6 @@ import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.methods.HttpHead;
 import org.apache.http.client.methods.HttpPut;
 import org.apache.http.client.methods.HttpUriRequest;
-import org.apache.http.protocol.HTTP;
 
 /**
  * 
@@ -32,7 +31,7 @@ public class HttpConfiguration
 {
     
     private static final HttpMethodConfiguration DEFAULT_PUT =
-        new HttpMethodConfiguration().addParam( HTTP.EXPECT_CONTINUE, "%b,true" );
+        new HttpMethodConfiguration().addParam( "http.protocol.expect-continue", "%b,true" );
 
     private HttpMethodConfiguration all;
 


### PR DESCRIPTION
There appear to be two issues:
* Expect-Continue is not enabled for PUT when no configuration is provided
* The default Expect-Continue configuration parameter uses the wrong key