### PR TITLE
[WAGON-485] ScpWagon file size Integer to Long

### DIFF
--- a/wagon-providers/wagon-ssh/src/main/java/org/apache/maven/wagon/providers/ssh/jsch/ScpWagon.java
+++ b/wagon-providers/wagon-ssh/src/main/java/org/apache/maven/wagon/providers/ssh/jsch/ScpWagon.java
@@ -297,7 +297,7 @@ public class ScpWagon
                 throw new IOException( "Invalid transfer header: " + line );
             }
 
-            int filesize = Integer.valueOf( line.substring( 5, index ) ).intValue();
+            long filesize = Long.parseLong( line.substring( 5, index ) );
             fireTransferDebug( "Remote file size: " + filesize );
 
             resource.setContentLength( filesize );


### PR DESCRIPTION
Change filesize to Long as `resource.setContentLength`