### PR TITLE
[WAGON-452] RelaxedTrustStrategy handle multiple certificates

### DIFF
--- a/wagon-providers/wagon-http-shared/src/main/java/org/apache/maven/wagon/shared/http/RelaxedTrustStrategy.java
+++ b/wagon-providers/wagon-http-shared/src/main/java/org/apache/maven/wagon/shared/http/RelaxedTrustStrategy.java
@@ -45,24 +45,27 @@ public class RelaxedTrustStrategy
     public boolean isTrusted( X509Certificate[] certificates, String authType )
         throws CertificateException
     {
-        if ( ( certificates != null ) && ( certificates.length == 1 ) )
+        if ( ( certificates != null ) && ( certificates.length > 0 ) )
         {
-            try
+            for ( X509Certificate currentCertificate : certificates ) 
             {
-                certificates[0].checkValidity();
-            }
-            catch ( CertificateExpiredException e )
-            {
-                if ( !ignoreSSLValidityDates )
+                try
                 {
-                    throw e;
+                    currentCertificate.checkValidity();
                 }
-            }
-            catch ( CertificateNotYetValidException e )
-            {
-                if ( !ignoreSSLValidityDates )
+                catch ( CertificateExpiredException e )
                 {
-                    throw e;
+                    if ( !ignoreSSLValidityDates )
+                    {
+                        throw e;
+                    }
+                }
+                catch ( CertificateNotYetValidException e )
+                {
+                    if ( !ignoreSSLValidityDates )
+                    {
+                        throw e;
+                    }
                 }
             }
             return true;


### PR DESCRIPTION
Ignoring ssl validity of dates is working, but in my case the server
returns 3 (expired) certificates.
With that RelaxedTrustStrategy always returned false.

When RelaxedTrustStrategy returns false, then trustManager.checkServerTrusted(...) runs into the CertificateExpiredException, so"maven.wagon.http.ssl.ignore.validity.dates" becomes obsolete.

The fix is to check all existing certificates in the given way.