### PR TITLE
[MNG-2802] Concurrent-safe access to local Maven repository

### DIFF
--- a/wagon-provider-api/src/main/java/org/apache/maven/wagon/LazyOutputStream.java
+++ b/wagon-provider-api/src/main/java/org/apache/maven/wagon/LazyOutputStream.java
@@ -1,0 +1,123 @@
+package org.apache.maven.wagon;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.io.IOException;
+import java.io.OutputStream;
+
+
+/**
+ * Abstract wrapper around OutputStream to allow lazy initialization through {@link #initialize()} method
+ *
+ * @author <a href="mailto:mmaczka@interia.pl">Michal Maczka</a>
+ * @author <a href="mailto:erikhakan@gmail.com">Erik Håkansson</a>
+ *
+ * @param <T> type of OutputStream
+ *
+ */
+public abstract class LazyOutputStream<T extends OutputStream>
+    extends OutputStream
+{
+
+    private T delegee;
+
+    public void close()
+        throws IOException
+    {
+        if ( delegee != null )
+        {
+            delegee.close();
+        }
+    }
+
+    public boolean equals( Object obj )
+    {
+        return delegee.equals( obj );
+    }
+
+    public void flush()
+        throws IOException
+    {
+        if ( delegee != null )
+        {
+            delegee.flush();
+        }
+    }
+
+    public int hashCode()
+    {
+        return delegee.hashCode();
+    }
+
+    public String toString()
+    {
+        return delegee.toString();
+    }
+
+    public void write( byte[] b )
+        throws IOException
+    {
+        if ( delegee == null )
+        {
+            initialize();
+        }
+
+        delegee.write( b );
+    }
+
+    /**
+     * @see OutputStream#write(byte[], int, int)
+     */
+    public void write( byte[] b, int off, int len )
+        throws IOException
+    {
+        if ( delegee == null )
+        {
+            initialize();
+        }
+        delegee.write( b, off, len );
+    }
+
+    /**
+     * @param b
+     * @throws IOException
+     */
+    public void write( int b )
+        throws IOException
+    {
+        if ( delegee == null )
+        {
+            initialize();
+        }
+        delegee.write( b );
+    }
+
+    protected abstract void initialize() throws IOException;
+
+    protected T getDelegee()
+    {
+        return delegee;
+    }
+
+    protected void setDelegee( T delegee )
+    {
+        this.delegee = delegee;
+    }
+}

--- a/wagon-providers/pom.xml
+++ b/wagon-providers/pom.xml
@@ -33,6 +33,7 @@ under the License.
 
   <modules>
     <module>wagon-file</module>
+    <module>wagon-file-test</module>
     <module>wagon-ftp</module>
     <module>wagon-http</module>
     <module>wagon-http-shared</module>

--- a/wagon-providers/wagon-file-test/pom.xml
+++ b/wagon-providers/wagon-file-test/pom.xml
@@ -1,0 +1,98 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <parent>
+    <artifactId>wagon-providers</artifactId>
+    <groupId>org.apache.maven.wagon</groupId>
+    <version>3.1.1-SNAPSHOT</version>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
+
+  <artifactId>wagon-file-test</artifactId>
+  <name>Apache Maven Wagon :: Providers :: File Provider Test</name>
+  <description>
+    Testing the File Provider
+  </description>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.apache.maven.wagon</groupId>
+      <artifactId>wagon-file</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>commons-io</groupId>
+      <artifactId>commons-io</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <configuration>
+          <excludes>
+            <exclude>**/*IntegrationTest.java</exclude>
+          </excludes>
+        </configuration>
+      </plugin>
+      <plugin>
+        <artifactId>maven-dependency-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>copy-dependencies</id>
+            <phase>pre-integration-test</phase>
+            <goals>
+              <goal>copy-dependencies</goal>
+            </goals>
+            <configuration>
+              <outputDirectory>${project.build.directory}/test-output/test-classpath</outputDirectory>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <artifactId>maven-failsafe-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>integration-test</id>
+            <phase>integration-test</phase>
+            <goals>
+              <goal>integration-test</goal>
+            </goals>
+          </execution>
+        </executions>
+        <configuration>
+          <includes>
+            <include>**/*IntegrationTest.java</include>
+          </includes>
+          <systemPropertyVariables>
+            <jarFile>${project.build.directory}/${project.build.finalName}.jar</jarFile>
+            <testOutputDir>${project.build.directory}/test-output/</testOutputDir>
+          </systemPropertyVariables>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>

--- a/wagon-providers/wagon-file-test/src/main/java/org/apache/maven/wagon/providers/file/LazyLockableFileOutputStreamTestDriver.java
+++ b/wagon-providers/wagon-file-test/src/main/java/org/apache/maven/wagon/providers/file/LazyLockableFileOutputStreamTestDriver.java
@@ -1,0 +1,75 @@
+package org.apache.maven.wagon.providers.file;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.io.File;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Test driver for LazyLockableFileOutputStreamIntegrationTest
+ */
+public class LazyLockableFileOutputStreamTestDriver
+{
+    public static void main( String[] args ) throws Exception
+    {
+        File file = new File( args[0] );
+        long timeout = Long.parseLong( args[1] );
+        long startTime = System.currentTimeMillis();
+        OutputStream outputStream = new LazyLockableFileOutputStream( file, timeout, TimeUnit.SECONDS );
+        try
+        {
+            outputStream.write( 1 );
+        }
+        catch ( IOException e )
+        {
+            if ( e.getMessage().equals( "Can't write file, lock " + file.getAbsolutePath() + ".lck exists" ) )
+            {
+                System.out.println( "ready" );
+                // CHECKSTYLE_OFF: MagicNumber
+                System.exit( 126 );
+                // CHECKSTYLE_ON: MagicNumber
+            }
+            else if ( e.getMessage().equals( "Failed to create lockfile " + file.getAbsolutePath()
+                    + ".lck after waiting " + timeout + " seconds. File already exists." ) )
+            {
+                long diff = System.currentTimeMillis() - startTime;
+                if ( diff < TimeUnit.SECONDS.toMillis( timeout ) )
+                {
+                    throw new Exception( "We were supposed to wait for " + timeout
+                            + " seconds, but Exception came early at " + diff + " milliseconds." );
+                }
+                System.out.println( "ready" );
+                // CHECKSTYLE_OFF: MagicNumber
+                System.exit( 127 );
+                // CHECKSTYLE_ON: MagicNumber
+            }
+            else
+            {
+                throw e;
+            }
+        }
+        System.out.println( "ready" );
+        //noinspection ResultOfMethodCallIgnored
+        System.in.read(); //wait for input to allow test to control when to exit.
+        outputStream.close();
+    }
+}

--- a/wagon-providers/wagon-file-test/src/test/java/org/apache/maven/wagon/providers/file/LazyLockableFileOutputStreamIntegrationTest.java
+++ b/wagon-providers/wagon-file-test/src/test/java/org/apache/maven/wagon/providers/file/LazyLockableFileOutputStreamIntegrationTest.java
@@ -1,0 +1,127 @@
+package org.apache.maven.wagon.providers.file;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import org.junit.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+public class LazyLockableFileOutputStreamIntegrationTest
+{
+
+    //This timeout is just to ensure a failing test doesn't hang indefinitely
+    private static final long processTimeoutInMilliseconds = 30000;
+    //This timeout is "real" and says how long to wait for a file lock
+    private static final String lockTimeoutInSeconds = "5";
+
+    @Test
+    public void testLockDontWait() throws Exception
+    {
+        String jarFile = System.getProperty( "jarFile" );
+        String testOutputDir = System.getProperty( "testOutputDir" );
+        String lockFile = testOutputDir + "lockfile1";
+        Process firstProcess = startProcess( jarFile, testOutputDir, lockFile, false );
+        waitForReady( firstProcess );
+        ensureNotExited( firstProcess, testOutputDir );
+
+        Process secondProcess = startProcess( jarFile, testOutputDir, lockFile, false );
+        waitForReady( secondProcess );
+
+        // CHECKSTYLE_OFF: MagicNumber
+        assertEquals( 126, secondProcess.waitFor() );
+        // CHECKSTYLE_ON: MagicNumber
+        firstProcess.getOutputStream().close();
+        assertEquals( 0, firstProcess.waitFor() );
+    }
+
+    @Test
+    public void testLockWait() throws Exception
+    {
+        String jarFile = System.getProperty( "jarFile" );
+        String testOutputDir = System.getProperty( "testOutputDir" );
+        String lockFile = testOutputDir + "lockfile2";
+        Process firstProcess = startProcess( jarFile, testOutputDir, lockFile, false );
+        waitForReady( firstProcess );
+        ensureNotExited( firstProcess, testOutputDir );
+
+        Process secondProcess = startProcess( jarFile, testOutputDir, lockFile, true );
+        waitForReady( secondProcess );
+        
+        // CHECKSTYLE_OFF: MagicNumber
+        assertEquals( 127, secondProcess.waitFor() );
+        // CHECKSTYLE_ON: MagicNumber
+        firstProcess.getOutputStream().close();
+        assertEquals( 0, firstProcess.waitFor() );
+    }
+
+    private void ensureNotExited(Process process, String testOutputDir) {
+        try
+        {
+            int exitValue = process.exitValue();
+            fail( "Lock process exited unexpectedly with status " + exitValue + ".\nSee " + testOutputDir
+                    + " /externalProcessOutput.txt for more info." );
+        }
+        catch ( IllegalThreadStateException ignore )
+        {
+            //We actually want this exception since we don't want the process to have ended
+        }
+    }
+
+    private void waitForReady( Process process ) throws IOException
+    {
+        InputStream inputStream = process.getInputStream();
+        int length;
+        byte[] buffer = new byte[1024];
+        ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
+        long startTime = System.currentTimeMillis();
+        while ( ( length = inputStream.read( buffer ) ) != -1 )
+        {
+            byteArrayOutputStream.write( buffer, 0, length );
+            if ( "ready".equals( byteArrayOutputStream.toString().trim() ) )
+            {
+                break;
+            }
+            if ( System.currentTimeMillis() - startTime > processTimeoutInMilliseconds )
+            {
+                byteArrayOutputStream.close();
+                fail( "Spawned process failed to get ready in less than " + processTimeoutInMilliseconds
+                        + " milliseconds." );
+            }
+        }
+        byteArrayOutputStream.close();
+    }
+
+    private Process startProcess( String jarFile, String testOutputDir, String lockFile, boolean waitForLock )
+            throws IOException
+    {
+        ProcessBuilder builder = new ProcessBuilder( "java", "-cp", jarFile + File.pathSeparatorChar + testOutputDir
+                + "test-classpath/*", LazyLockableFileOutputStreamTestDriver.class.getName(), lockFile,
+                waitForLock ? lockTimeoutInSeconds : "0" );
+        builder.redirectError( ProcessBuilder.Redirect.appendTo(
+                new File( testOutputDir + "externalProcessOutput.txt" ) ) );
+        return builder.start();
+    }
+}

--- a/wagon-providers/wagon-file/pom.xml
+++ b/wagon-providers/wagon-file/pom.xml
@@ -42,5 +42,9 @@ under the License.
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-simple</artifactId>
     </dependency>
+    <dependency>
+      <groupId>commons-io</groupId>
+      <artifactId>commons-io</artifactId>
+    </dependency>
   </dependencies>
 </project>

--- a/wagon-providers/wagon-file/src/main/java/org/apache/maven/wagon/providers/file/WaitingLockableFileWriter.java
+++ b/wagon-providers/wagon-file/src/main/java/org/apache/maven/wagon/providers/file/WaitingLockableFileWriter.java
@@ -1,0 +1,301 @@
+package org.apache.maven.wagon.providers.file;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import org.apache.commons.io.Charsets;
+import org.apache.commons.io.FileUtils;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.OutputStreamWriter;
+import java.io.Writer;
+import java.nio.charset.Charset;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * CHECKSTYLE_OFF: LineLength
+ * Adapted from commons-io LockableFileWriter
+ * https://github.com/apache/commons-io/blob/58b0f795b31482daa6bb5473a8b2c398e029f5fb/src/main/java/org/apache/commons/io/output/LockableFileWriter.java
+ * licenced under apache-2.0
+ *
+ * Aside from some clean-up of not used parts, the main difference is that we can optionally wait for a file lock.
+ *
+ * @author <a href="mailto:erikhakan@gmail.com">Erik Håkansson</a>
+ * CHECKSTYLE_ON: LineLength
+ */
+public class WaitingLockableFileWriter extends Writer
+{
+    // Cannot extend ProxyWriter, as requires writer to be
+    // known when super() is called
+
+    /**
+     * The extension for the lock file.
+     */
+    private static final String LCK = ".lck";
+
+    /**
+     * The writer to decorate.
+     */
+    private final Writer out;
+    /**
+     * The lock file.
+     */
+    private final File lockFile;
+
+    /**
+     * Constructs a WaitingLockableFileWriter with a file encoding.
+     *
+     * @param file        the file to write to, not null
+     * @param encoding    the encoding to use, null means platform default
+     * @param append      true if content should be appended, false to overwrite
+     * @param lockDir     the directory in which the lock file should be held
+     * @param timeout     how long to wait for a lock if file is already locked
+     * @param timeoutUnit unit of timeout
+     * @param wait        should we wait while trying to obtain lock
+     * @throws NullPointerException if the file is null
+     * @throws IOException          in case of an I/O error
+     * @since 2.3
+     */
+    public WaitingLockableFileWriter( File file, final Charset encoding, final boolean append, String lockDir,
+                                      long timeout, TimeUnit timeoutUnit, boolean wait ) throws IOException
+    {
+        super();
+        // init file to create/append
+        file = file.getAbsoluteFile();
+        if ( file.getParentFile() != null )
+        {
+            FileUtils.forceMkdir( file.getParentFile() );
+        }
+        if ( file.isDirectory() )
+        {
+            throw new IOException( "File specified is a directory" );
+        }
+
+        // init lock file
+        if ( lockDir == null )
+        {
+            lockDir = System.getProperty( "java.io.tmpdir" );
+        }
+        final File lockDirFile = new File( lockDir );
+        FileUtils.forceMkdir( lockDirFile );
+        testLockDir( lockDirFile );
+        lockFile = new File( lockDirFile, file.getName() + LCK );
+
+        // check if locked
+        createLock( wait, timeout, timeoutUnit );
+
+        // init wrapped writer
+        out = initWriter( file, encoding, append );
+    }
+
+    //-----------------------------------------------------------------------
+
+    /**
+     * Tests that we can write to the lock directory.
+     *
+     * @param lockDir the File representing the lock directory
+     * @throws IOException if we cannot write to the lock directory
+     * @throws IOException if we cannot find the lock file
+     */
+    private void testLockDir( final File lockDir ) throws IOException
+    {
+        if ( !lockDir.exists() )
+        {
+            throw new IOException(
+                    "Could not find lockDir: " + lockDir.getAbsolutePath() );
+        }
+        if ( !lockDir.canWrite() )
+        {
+            throw new IOException(
+                    "Could not write to lockDir: " + lockDir.getAbsolutePath() );
+        }
+    }
+
+    /**
+     * Creates the lock file.
+     *
+     * @param timeout     how long to wait for a lock if file is already locked
+     * @param timeoutUnit unit of timeout
+     * @param wait
+     * @throws IOException if we cannot create the file
+     */
+    private void createLock( boolean wait, long timeout, TimeUnit timeoutUnit ) throws IOException
+    {
+        synchronized ( WaitingLockableFileWriter.class )
+        {
+            if ( wait && lockFile.exists() )
+            {
+                long startTime = System.currentTimeMillis();
+                long timeoutInMilliseconds = timeoutUnit.toMillis( timeout );
+                while ( lockFile.exists() )
+                {
+                    if ( System.currentTimeMillis() - startTime >= timeoutInMilliseconds )
+                    {
+                        throw new IOException( "Failed to create lockfile " + lockFile + " after waiting "
+                                + timeoutUnit.toSeconds( timeout ) + " seconds. File already exists." );
+                    }
+                    try
+                    {
+                        Thread.sleep( 512 );
+                    }
+                    catch ( InterruptedException e )
+                    {
+                        throw new IOException( e );
+                    }
+                }
+            }
+            if ( !lockFile.createNewFile() )
+            {
+                //Shouldn't happen if we waited above, but if not, this is possible.
+                throw new IOException( "Can't write file, lock " + lockFile.getAbsolutePath() + " exists" );
+            }
+            lockFile.deleteOnExit();
+        }
+    }
+
+    /**
+     * Initialise the wrapped file writer.
+     * Ensure that a cleanup occurs if the writer creation fails.
+     *
+     * @param file     the file to be accessed
+     * @param encoding the encoding to use
+     * @param append   true to append
+     * @return The initialised writer
+     * @throws IOException if an error occurs
+     */
+    private Writer initWriter( final File file, final Charset encoding, final boolean append ) throws IOException
+    {
+        final boolean fileExistedAlready = file.exists();
+        try
+        {
+            return new OutputStreamWriter( new FileOutputStream( file.getAbsolutePath(), append ),
+                    Charsets.toCharset( encoding ) );
+
+        }
+        catch ( final IOException | RuntimeException ex )
+        {
+            FileUtils.deleteQuietly( lockFile );
+            if ( !fileExistedAlready )
+            {
+                FileUtils.deleteQuietly( file );
+            }
+            throw ex;
+        }
+    }
+
+    //-----------------------------------------------------------------------
+
+    /**
+     * Closes the file writer and deletes the lockfile (if possible).
+     *
+     * @throws IOException if an I/O error occurs
+     */
+    @Override
+    public void close() throws IOException
+    {
+        try
+        {
+            out.close();
+        }
+        finally
+        {
+            lockFile.delete();
+        }
+    }
+
+    //-----------------------------------------------------------------------
+
+    /**
+     * Write a character.
+     *
+     * @param idx the character to write
+     * @throws IOException if an I/O error occurs
+     */
+    @Override
+    public void write( final int idx ) throws IOException
+    {
+        out.write( idx );
+    }
+
+    /**
+     * Write the characters from an array.
+     *
+     * @param chr the characters to write
+     * @throws IOException if an I/O error occurs
+     */
+    @Override
+    public void write( final char[] chr ) throws IOException
+    {
+        out.write( chr );
+    }
+
+    /**
+     * Write the specified characters from an array.
+     *
+     * @param chr the characters to write
+     * @param st  The start offset
+     * @param end The number of characters to write
+     * @throws IOException if an I/O error occurs
+     */
+    @Override
+    public void write( final char[] chr, final int st, final int end ) throws IOException
+    {
+        out.write( chr, st, end );
+    }
+
+    /**
+     * Write the characters from a string.
+     *
+     * @param str the string to write
+     * @throws IOException if an I/O error occurs
+     */
+    @Override
+    public void write( final String str ) throws IOException
+    {
+        out.write( str );
+    }
+
+    /**
+     * Write the specified characters from a string.
+     *
+     * @param str the string to write
+     * @param st  The start offset
+     * @param end The number of characters to write
+     * @throws IOException if an I/O error occurs
+     */
+    @Override
+    public void write( final String str, final int st, final int end ) throws IOException
+    {
+        out.write( str, st, end );
+    }
+
+    /**
+     * Flush the stream.
+     *
+     * @throws IOException if an I/O error occurs
+     */
+    @Override
+    public void flush() throws IOException
+    {
+        out.flush();
+    }
+
+}


### PR DESCRIPTION
Made file wagon optionally lock files using an adapted version of LockableFileWriter from commons-io.

Integration test is made by forking two separate java processes that attempts to lock the same file. Only the first will succeed.

At first I tried using Java's FileLock, but that proved impossible on Windows Subsystem for Linux as that doesn't reliably support file locks, and after some googling I realized the native FileLocks are generally unreliable from Java. Instead I opted to use lockfiles using the commons-io approach.

Use system property maven.wagon.file.fileLock=true to enable file lock. Default is off, default timeout is 300 seconds, but configurable with maven.wagon.file.fileLock.timeout