### PR TITLE
WAGON-557 

### DIFF
--- a/wagon-provider-api/src/main/java/org/apache/maven/wagon/AbstractWagon.java
+++ b/wagon-provider-api/src/main/java/org/apache/maven/wagon/AbstractWagon.java
@@ -643,10 +643,14 @@ public abstract class AbstractWagon
             return DEFAULT_BUFFER_SIZE;
         }
 
-        final int numberOfBufferSegments = (int)
-            numberOfBytes / ( BUFFER_SEGMENT_SIZE * MINIMUM_AMOUNT_OF_TRANSFER_CHUNKS );
-        final int potentialBufferSize = numberOfBufferSegments * BUFFER_SEGMENT_SIZE;
-        return min( MAXIMUM_BUFFER_SIZE, max( DEFAULT_BUFFER_SIZE, potentialBufferSize ) );
+        final long numberOfBufferSegments =  numberOfBytes
+                / ( BUFFER_SEGMENT_SIZE * MINIMUM_AMOUNT_OF_TRANSFER_CHUNKS );
+        final long potentialBufferSize = numberOfBufferSegments * BUFFER_SEGMENT_SIZE;
+        if ( potentialBufferSize > Integer.MAX_VALUE )
+        {
+            return MAXIMUM_BUFFER_SIZE;
+        }
+        return min( MAXIMUM_BUFFER_SIZE, max( DEFAULT_BUFFER_SIZE, (int) potentialBufferSize ) );
     }
 
     // ----------------------------------------------------------------------

--- a/wagon-provider-api/src/test/java/org/apache/maven/wagon/AbstractWagonTest.java
+++ b/wagon-provider-api/src/test/java/org/apache/maven/wagon/AbstractWagonTest.java
@@ -117,6 +117,23 @@ public class AbstractWagonTest
 
     }
 
+    public void testCalculationOfTransferBufferSize() {
+        // 1 KB -> Default buffer size (4k)
+        assertEquals( 4096, wagon.getBufferCapacityForTransfer(1024L ) );
+
+        // 1 MB -> Twice the default buffer size (8 KB)
+        assertEquals( 4096 * 2, wagon.getBufferCapacityForTransfer(1024L * 1024 ) );
+
+        // 100 MB -> Maximum buffer size (512 KB)
+        assertEquals( 4096 * 128, wagon.getBufferCapacityForTransfer(1024L * 1024  * 100 ) );
+
+        // 1 GB -> Maximum buffer size (512 KB)
+        assertEquals( 4096 * 128, wagon.getBufferCapacityForTransfer(1024L * 1024  * 1024 ) );
+
+        // 100 GB -> Maximum buffer size (512 KB)
+        assertEquals( 4096 * 128, wagon.getBufferCapacityForTransfer(1024L * 1024  * 1024 * 100 ) );
+    }
+
     public void testSessionListenerRegistration()
     {
         assertTrue( wagon.hasSessionListener( sessionListener ) );


### PR DESCRIPTION
Wrap around in AbstractWagon.getBufferCapacityForTransfer Prevents optimal buffer size selection for large artifacts

Made the handling of overly large potential buffer sizes more explicit