### PR TITLE
Fix cast exception, when the server returns an xml containing a newli…

### DIFF
--- a/wagon-providers/wagon-webdav-jackrabbit/src/main/java/org/apache/maven/wagon/providers/webdav/WebDavWagon.java
+++ b/wagon-providers/wagon-webdav-jackrabbit/src/main/java/org/apache/maven/wagon/providers/webdav/WebDavWagon.java
@@ -44,6 +44,7 @@ import org.apache.maven.wagon.repository.Repository;
 import org.apache.maven.wagon.shared.http.AbstractHttpClientWagon;
 import org.codehaus.plexus.util.FileUtils;
 import org.codehaus.plexus.util.StringUtils;
+import org.w3c.dom.Element;
 import org.w3c.dom.Node;
 
 import java.io.File;
@@ -226,7 +227,23 @@ public class WebDavWagon
                 DavProperty<?> property = propertySet.get( DavConstants.PROPERTY_RESOURCETYPE );
                 if ( property != null )
                 {
-                    Node node = (Node) property.getValue();
+                    Object value = property.getValue();
+                    Node node = null;
+                    if ( value instanceof Element )
+                    {
+                        node = ( Node ) value;
+                    }
+                    else if ( value instanceof List )
+                    {
+                        for ( Object o : ( List ) value )
+                        {
+                            if ( o instanceof Element )
+                            {
+                                node = ( Node ) o;
+                                break;
+                            }
+                        }
+                    }
                     return node.getLocalName().equals( DavConstants.XML_COLLECTION );
                 }
             }


### PR DESCRIPTION
Fix cast exception, when the server returns an xml containing a newline, property.getValue() is an ArrayList

eg。
<?xml version="1.0"?>
<d:multistatus xmlns:d="DAV:" xmlns:s="http://sabredav.org/ns" xmlns:oc="http://owncloud.org/ns">
 <d:response>
  <d:href>/remote.php/webdav/</d:href>
  <d:propstat>
   <d:prop>
    <d:resourcetype>
     <d:collection/>
    </d:resourcetype>
   </d:prop>
   <d:status>HTTP/1.1 200 OK</d:status>
  </d:propstat>
 </d:response>
</d:multistatus>