### PR TITLE
Speedup CI builds with hashver-maven-plugin?

### DIFF
--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -1,0 +1,9 @@
+<extensions xmlns="http://maven.apache.org/EXTENSIONS/1.0.0"
+            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xsi:schemaLocation="http://maven.apache.org/EXTENSIONS/1.0.0 http://maven.apache.org/xsd/core-extensions-1.0.0.xsd">
+    <extension>
+        <groupId>pro.avodonosov</groupId>
+        <artifactId>hashver-maven-plugin</artifactId>
+        <version>1.6</version>
+    </extension>
+</extensions>

--- a/README.md
+++ b/README.md
@@ -14,6 +14,13 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 -->
+Fork Info
+======================
+This fork is to test the [hashver-maven-plugin](https://github.com/avodonosov/hashver-maven-plugin).
+
+Original README is below.
+======================
+
 Contributing to [Apache Maven Wagon](https://maven.apache.org/wagon/)
 ======================
 

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@ under the License.
 
   <groupId>org.apache.maven.wagon</groupId>
   <artifactId>wagon</artifactId>
-  <version>3.4.2-SNAPSHOT</version>
+  <version>${wagon.version}</version>
   <packaging>pom</packaging>
 
   <name>Apache Maven Wagon</name>
@@ -230,22 +230,22 @@ under the License.
       <dependency>
         <groupId>org.apache.maven.wagon</groupId>
         <artifactId>wagon-provider-api</artifactId>
-        <version>${project.version}</version>
+        <version>${wagon-provider-api.version}</version>
       </dependency>
       <dependency>
         <groupId>org.apache.maven.wagon</groupId>
         <artifactId>wagon-provider-test</artifactId>
-        <version>${project.version}</version>
+        <version>${wagon-provider-test.version}</version>
       </dependency>
       <dependency>
         <groupId>org.apache.maven.wagon</groupId>
         <artifactId>wagon-ssh-common-test</artifactId>
-        <version>${project.version}</version>
+        <version>${wagon-ssh-common-test.version}</version>
       </dependency>
       <dependency>
         <groupId>org.apache.maven.wagon</groupId>
         <artifactId>wagon-ssh-common</artifactId>
-        <version>${project.version}</version>
+        <version>${wagon-ssh-common.version}</version>
       </dependency>
       <dependency>
         <groupId>junit</groupId>
@@ -356,6 +356,8 @@ under the License.
           <artifactId>apache-rat-plugin</artifactId>
           <configuration>
             <excludes combine.children="append">
+              <exclude>versions.properties</exclude>
+              <exclude>.mvn/extensions.xml</exclude>
               <exclude>.checkstyle</exclude>
               <exclude>**/*.odg</exclude>
               <exclude>src/test/resources/**</exclude>
@@ -445,6 +447,31 @@ under the License.
                 </requireJavaVersion>
               </rules>
             </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>flatten-maven-plugin</artifactId>
+        <version>1.2.2</version>
+        <configuration>
+        </configuration>
+        <executions>
+          <!-- enable flattening -->
+          <execution>
+            <id>flatten</id>
+            <phase>process-resources</phase>
+            <goals>
+              <goal>flatten</goal>
+            </goals>
+          </execution>
+          <!-- ensure proper cleanup -->
+          <execution>
+            <id>flatten.clean</id>
+            <phase>clean</phase>
+            <goals>
+              <goal>clean</goal>
+            </goals>
           </execution>
         </executions>
       </plugin>

--- a/versions.properties
+++ b/versions.properties
@@ -1,0 +1,17 @@
+wagon-file.version=3.4.2-SNAPSHOT
+wagon-ftp.version=3.4.2-SNAPSHOT
+wagon-http-lightweight.version=3.4.2-SNAPSHOT
+wagon-http-shared.version=3.4.2-SNAPSHOT
+wagon-http.version=3.4.2-SNAPSHOT
+wagon-provider-api.version=3.4.2-SNAPSHOT
+wagon-provider-test.version=3.4.2-SNAPSHOT
+wagon-providers.version=3.4.2-SNAPSHOT
+wagon-scm.version=3.4.2-SNAPSHOT
+wagon-ssh-common-test.version=3.4.2-SNAPSHOT
+wagon-ssh-common.version=3.4.2-SNAPSHOT
+wagon-ssh-external.version=3.4.2-SNAPSHOT
+wagon-ssh.version=3.4.2-SNAPSHOT
+wagon-tck-http.version=-3.4.2-SNAPSHOT
+wagon-tcks.version=3.4.2-SNAPSHOT
+wagon-webdav-jackrabbit.version=3.4.2-SNAPSHOT
+wagon.version=3.4.2-SNAPSHOT

--- a/wagon-provider-api/pom.xml
+++ b/wagon-provider-api/pom.xml
@@ -23,11 +23,12 @@ under the License.
   <parent>
     <groupId>org.apache.maven.wagon</groupId>
     <artifactId>wagon</artifactId>
-    <version>3.4.2-SNAPSHOT</version>
+    <version>${wagon.version}</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
   <artifactId>wagon-provider-api</artifactId>
+  <version>${wagon-provider-api.version}</version>
   <name>Apache Maven Wagon :: API</name>
   <description>Maven Wagon API that defines the contract between different Wagon implementations</description>
 

--- a/wagon-provider-test/pom.xml
+++ b/wagon-provider-test/pom.xml
@@ -23,11 +23,12 @@ under the License.
   <parent>
     <groupId>org.apache.maven.wagon</groupId>
     <artifactId>wagon</artifactId>
-    <version>3.4.2-SNAPSHOT</version>
+    <version>${wagon.version}</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
   <artifactId>wagon-provider-test</artifactId>
+  <version>${wagon-provider-test.version}</version>
   <name>Apache Maven Wagon :: Provider Test</name>
   <description>Suite of tests for Wagon implementations</description>
 

--- a/wagon-providers/pom.xml
+++ b/wagon-providers/pom.xml
@@ -23,11 +23,12 @@ under the License.
   <parent>
     <groupId>org.apache.maven.wagon</groupId>
     <artifactId>wagon</artifactId>
-    <version>3.4.2-SNAPSHOT</version>
+    <version>${wagon.version}</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
   <artifactId>wagon-providers</artifactId>
+  <version>${wagon-providers.version}</version>
   <packaging>pom</packaging>
   <name>Apache Maven Wagon :: Providers</name>
 

--- a/wagon-providers/wagon-file/pom.xml
+++ b/wagon-providers/wagon-file/pom.xml
@@ -23,11 +23,12 @@ under the License.
   <parent>
     <groupId>org.apache.maven.wagon</groupId>
     <artifactId>wagon-providers</artifactId>
-    <version>3.4.2-SNAPSHOT</version>
+    <version>${wagon-providers.version}</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
   <artifactId>wagon-file</artifactId>
+  <version>${wagon-file.version}</version>
   <name>Apache Maven Wagon :: Providers :: File Provider</name>
   <description>
     Wagon provider that gets and puts artifacts using file system protocol

--- a/wagon-providers/wagon-ftp/pom.xml
+++ b/wagon-providers/wagon-ftp/pom.xml
@@ -23,11 +23,12 @@ under the License.
   <parent>
     <groupId>org.apache.maven.wagon</groupId>
     <artifactId>wagon-providers</artifactId>
-    <version>3.4.2-SNAPSHOT</version>
+    <version>${wagon-providers.version}</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
   <artifactId>wagon-ftp</artifactId>
+  <version>${wagon-ftp.version}</version>
   <name>Apache Maven Wagon :: Providers :: FTP Provider</name>
   <description>
     Wagon provider that gets and puts artifacts from and to remote server using FTP protocol

--- a/wagon-providers/wagon-http-lightweight/pom.xml
+++ b/wagon-providers/wagon-http-lightweight/pom.xml
@@ -23,11 +23,12 @@ under the License.
   <parent>
     <groupId>org.apache.maven.wagon</groupId>
     <artifactId>wagon-providers</artifactId>
-    <version>3.4.2-SNAPSHOT</version>
+    <version>${wagon-providers.version}</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
   <artifactId>wagon-http-lightweight</artifactId>
+  <version>${wagon-http-lightweight.version}</version>
   <name>Apache Maven Wagon :: Providers :: Lightweight HTTP Provider</name>
   <description>
     Wagon provider that gets and puts artifacts through http using standard Java library
@@ -37,14 +38,14 @@ under the License.
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>wagon-http-shared</artifactId>
-      <version>${project.version}</version>
+      <version>${wagon-http-shared.version}</version>
     </dependency>
 
     <!-- used fo the TCK -->
     <dependency>
       <groupId>org.apache.maven.wagon</groupId>
       <artifactId>wagon-tck-http</artifactId>
-      <version>${project.version}</version>
+      <version>${wagon-tck-http.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/wagon-providers/wagon-http-shared/pom.xml
+++ b/wagon-providers/wagon-http-shared/pom.xml
@@ -23,11 +23,12 @@ under the License.
   <parent>
     <groupId>org.apache.maven.wagon</groupId>
     <artifactId>wagon-providers</artifactId>
-    <version>3.4.2-SNAPSHOT</version>
+    <version>${wagon-providers.version}</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
   <artifactId>wagon-http-shared</artifactId>
+  <version>${wagon-http-shared.version}</version>
   <name>Apache Maven Wagon :: Providers :: HTTP Shared Library</name>
   <description>
     Shared Library for wagon providers supporting HTTP.

--- a/wagon-providers/wagon-http/pom.xml
+++ b/wagon-providers/wagon-http/pom.xml
@@ -23,11 +23,12 @@ under the License.
   <parent>
     <groupId>org.apache.maven.wagon</groupId>
     <artifactId>wagon-providers</artifactId>
-    <version>3.4.2-SNAPSHOT</version>
+    <version>${wagon-providers.version}</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
   <artifactId>wagon-http</artifactId>
+  <version>${wagon-http.version}</version>
   <name>Apache Maven Wagon :: Providers :: HTTP Provider</name>
   <description>
     Wagon provider that gets and puts artifacts through HTTP(S) using Apache HttpClient-4.x.
@@ -38,7 +39,7 @@ under the License.
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>wagon-http-shared</artifactId>
-      <version>${project.version}</version>
+      <version>${wagon-http-shared.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.httpcomponents</groupId>
@@ -97,7 +98,7 @@ under the License.
     <dependency>
       <groupId>org.apache.maven.wagon</groupId>
       <artifactId>wagon-tck-http</artifactId>
-      <version>${project.version}</version>
+      <version>${wagon-tck-http.version}</version>
       <scope>test</scope>
     </dependency>
 

--- a/wagon-providers/wagon-scm/pom.xml
+++ b/wagon-providers/wagon-scm/pom.xml
@@ -23,11 +23,12 @@ under the License.
   <parent>
     <groupId>org.apache.maven.wagon</groupId>
     <artifactId>wagon-providers</artifactId>
-    <version>3.4.2-SNAPSHOT</version>
+    <version>${wagon-providers.version}</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
   <artifactId>wagon-scm</artifactId>
+  <version>${wagon-scm.version}</version>
   <name>Apache Maven Wagon :: Providers :: SCM Provider</name>
   <description>
     Wagon provider that gets and puts artifacts using a Source Control Management system

--- a/wagon-providers/wagon-ssh-common-test/pom.xml
+++ b/wagon-providers/wagon-ssh-common-test/pom.xml
@@ -23,11 +23,12 @@ under the License.
   <parent>
     <groupId>org.apache.maven.wagon</groupId>
     <artifactId>wagon-providers</artifactId>
-    <version>3.4.2-SNAPSHOT</version>
+    <version>${wagon-providers.version}</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
   <artifactId>wagon-ssh-common-test</artifactId>
+  <version>${wagon-ssh-common-test.version}</version>
   <name>Apache Maven Wagon :: Providers :: SSH Common Tests</name>
 
   <dependencies>

--- a/wagon-providers/wagon-ssh-common/pom.xml
+++ b/wagon-providers/wagon-ssh-common/pom.xml
@@ -23,11 +23,12 @@ under the License.
   <parent>
     <groupId>org.apache.maven.wagon</groupId>
     <artifactId>wagon-providers</artifactId>
-    <version>3.4.2-SNAPSHOT</version>
+    <version>${wagon-providers.version}</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
   <artifactId>wagon-ssh-common</artifactId>
+  <version>${wagon-ssh-common.version}</version>
   <name>Apache Maven Wagon :: Providers :: SSH Common Library</name>
 
   <dependencies>

--- a/wagon-providers/wagon-ssh-external/pom.xml
+++ b/wagon-providers/wagon-ssh-external/pom.xml
@@ -23,11 +23,12 @@ under the License.
   <parent>
     <groupId>org.apache.maven.wagon</groupId>
     <artifactId>wagon-providers</artifactId>
-    <version>3.4.2-SNAPSHOT</version>
+    <version>${wagon-providers.version}</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
   <artifactId>wagon-ssh-external</artifactId>
+  <version>${wagon-ssh-external.version}</version>
   <name>Apache Maven Wagon :: Providers :: SSH External Provider</name>
   <description>
     Wagon provider that gets and puts artifacts using SSH protocol with a preinstalled SSH client

--- a/wagon-providers/wagon-ssh/pom.xml
+++ b/wagon-providers/wagon-ssh/pom.xml
@@ -23,11 +23,12 @@ under the License.
   <parent>
     <groupId>org.apache.maven.wagon</groupId>
     <artifactId>wagon-providers</artifactId>
-    <version>3.4.2-SNAPSHOT</version>
+    <version>${wagon-providers.version}</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
   <artifactId>wagon-ssh</artifactId>
+  <version>${wagon-ssh.version}</version>
   <name>Apache Maven Wagon :: Providers :: SSH Provider</name>
 
   <properties>

--- a/wagon-providers/wagon-webdav-jackrabbit/pom.xml
+++ b/wagon-providers/wagon-webdav-jackrabbit/pom.xml
@@ -23,11 +23,12 @@ under the License.
   <parent>
     <groupId>org.apache.maven.wagon</groupId>
     <artifactId>wagon-providers</artifactId>
-    <version>3.4.2-SNAPSHOT</version>
+    <version>${wagon-providers.version}</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
   <artifactId>wagon-webdav-jackrabbit</artifactId>
+  <version>${wagon-webdav-jackrabbit.version}</version>
   <name>Apache Maven Wagon :: Providers :: WebDAV Provider</name>
   <description>
     Wagon provider that gets and puts artifacts through WebDAV protocol
@@ -49,7 +50,7 @@ under the License.
       <!-- Workaround for QDOX-148, see also MNG-3686 -->
       <groupId>${project.groupId}</groupId>
       <artifactId>wagon-http-shared</artifactId>
-      <version>${project.version}</version>
+      <version>${wagon-http-shared.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.jackrabbit</groupId>

--- a/wagon-tcks/pom.xml
+++ b/wagon-tcks/pom.xml
@@ -23,11 +23,12 @@ under the License.
   <parent>
     <groupId>org.apache.maven.wagon</groupId>
     <artifactId>wagon</artifactId>
-    <version>3.4.2-SNAPSHOT</version>
+    <version>${wagon.version}</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
   <artifactId>wagon-tcks</artifactId>
+  <version>${wagon-tcks.version}</version>
   <packaging>pom</packaging>
   <name>Apache Maven Wagon :: Test Compatibility Kits</name>
 

--- a/wagon-tcks/wagon-tck-http/pom.xml
+++ b/wagon-tcks/wagon-tck-http/pom.xml
@@ -23,11 +23,12 @@ under the License.
   <parent>
     <groupId>org.apache.maven.wagon</groupId>
     <artifactId>wagon-tcks</artifactId>
-    <version>3.4.2-SNAPSHOT</version>
+    <version>${wagon-tcks.version}</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
   <artifactId>wagon-tck-http</artifactId>
+  <version>${wagon-tck-http.version}</version>
 
   <name>Apache Maven Wagon :: HTTP Test Compatibility Kit</name>
 


### PR DESCRIPTION
Hi, are you interested to speedup Ci builds?

I'm working on a tool that allows to build and test only submodules affected by the changes (taking the dependency tree into account) - https://github.com/avodonosov/hashver-maven-plugin - and use the maven-wagon project as a testbench for the tool.

This PR demonstrates how to integrate the tool into the project.

CI scripts need to be adjusted too. If you are interested I can help with that.

Best regards,
- Anton