### PR TITLE
[MNG-6975] Wagon-HTTP, set content-type when determinable from file extension 

### DIFF
--- a/wagon-providers/pom.xml
+++ b/wagon-providers/pom.xml
@@ -78,4 +78,20 @@ under the License.
       <scope>test</scope>
     </dependency>
   </dependencies>
+
+  <profiles>
+    <profile>
+      <id>jdk11</id>
+      <activation>
+        <jdk>[1.11,)</jdk>
+      </activation>
+      <dependencies>
+        <dependency>
+          <groupId>com.sun.activation</groupId>
+          <artifactId>javax.activation</artifactId>
+          <version>1.2.0</version>
+        </dependency>
+      </dependencies>
+    </profile>
+  </profiles>
 </project>

--- a/wagon-providers/pom.xml
+++ b/wagon-providers/pom.xml
@@ -79,19 +79,4 @@ under the License.
     </dependency>
   </dependencies>
 
-  <profiles>
-    <profile>
-      <id>jdk11</id>
-      <activation>
-        <jdk>[1.11,)</jdk>
-      </activation>
-      <dependencies>
-        <dependency>
-          <groupId>com.sun.activation</groupId>
-          <artifactId>javax.activation</artifactId>
-          <version>1.2.0</version>
-        </dependency>
-      </dependencies>
-    </profile>
-  </profiles>
 </project>

--- a/wagon-providers/wagon-http-shared/src/main/java/org/apache/maven/wagon/shared/http/AbstractHttpClientWagon.java
+++ b/wagon-providers/wagon-http-shared/src/main/java/org/apache/maven/wagon/shared/http/AbstractHttpClientWagon.java
@@ -145,7 +145,7 @@ public abstract class AbstractHttpClientWagon
             {
                 this.source = source;
                 this.repeatable = true;
-                final String mimeType = FILE_TYPE_MAP.getContentType( source );
+                final String mimeType = SET_CONTENT_TYPE_FROM_FILE_EXTENSION ? FILE_TYPE_MAP.getContentType( source ) : null;
                 if ( mimeType != null && !mimeType.isEmpty() )
                 {
                     setContentType( mimeType );
@@ -288,6 +288,12 @@ public abstract class AbstractHttpClientWagon
     private static final boolean SSL_ALLOW_ALL =
         Boolean.valueOf( System.getProperty( "maven.wagon.http.ssl.allowall", "false" ) );
 
+    /**
+     * If enabled, ssl hostname verifier does not check hostname. Disable this will use a browser compat hostname
+     * verifier <b>disabled by default</b>
+     */
+    private static final boolean SET_CONTENT_TYPE_FROM_FILE_EXTENSION =
+            Boolean.valueOf( System.getProperty( "maven.wagon.http.file.autocontenttype", "false" ) );
 
     /**
      * Maximum concurrent connections per distinct route.

--- a/wagon-providers/wagon-http-shared/src/main/java/org/apache/maven/wagon/shared/http/AbstractHttpClientWagon.java
+++ b/wagon-providers/wagon-http-shared/src/main/java/org/apache/maven/wagon/shared/http/AbstractHttpClientWagon.java
@@ -145,7 +145,9 @@ public abstract class AbstractHttpClientWagon
             {
                 this.source = source;
                 this.repeatable = true;
-                final String mimeType = SET_CONTENT_TYPE_FROM_FILE_EXTENSION ? FILE_TYPE_MAP.getContentType( source ) : null;
+                final String mimeType = SET_CONTENT_TYPE_FROM_FILE_EXTENSION
+                        ? FILE_TYPE_MAP.getContentType( source )
+                        : null;
                 if ( mimeType != null && !mimeType.isEmpty() )
                 {
                     setContentType( mimeType );

--- a/wagon-providers/wagon-http-shared/src/main/java/org/apache/maven/wagon/shared/http/AbstractHttpClientWagon.java
+++ b/wagon-providers/wagon-http-shared/src/main/java/org/apache/maven/wagon/shared/http/AbstractHttpClientWagon.java
@@ -175,11 +175,24 @@ public abstract class AbstractHttpClientWagon
             }
         }
 
+        /**
+         * Try to determine the content type and set the content-type header if successful.
+         *
+         * if the content-type has not been set then
+         * if the (AUTOSET_CONTENT_TYPE) option flag is TRUE
+         * and
+         * the content is coming from a file and the content type is determinable from the file extension
+         * or
+         * the content is coming from a stream and the content type is determinable from the stream
+         *     (guessContentTypeFromStream will return null if the InputStream does not support mark())
+         * then determine and set the content type
+         * Note: the content-type will never be set to null or an empty string by this method.
+         *
+         * @throws IOException - indicates a failure when trying to determine the content type of a stream, will
+         * never occur when the content is coming from File
+         */
         private void autosetContentType() throws IOException
         {
-            // if the content-type has not been set then
-            // if the option flag is TRUE and the content type is determinable from the file extension
-            // then set it from the file extension
             final String mimeType = AUTOSET_CONTENT_TYPE
                     ? this.source != null
                         ? URLConnection.guessContentTypeFromName( source.getName() )

--- a/wagon-providers/wagon-http-shared/src/main/java/org/apache/maven/wagon/shared/http/AbstractHttpClientWagon.java
+++ b/wagon-providers/wagon-http-shared/src/main/java/org/apache/maven/wagon/shared/http/AbstractHttpClientWagon.java
@@ -291,8 +291,9 @@ public abstract class AbstractHttpClientWagon
         Boolean.valueOf( System.getProperty( "maven.wagon.http.ssl.allowall", "false" ) );
 
     /**
-     * If enabled, ssl hostname verifier does not check hostname. Disable this will use a browser compat hostname
-     * verifier <b>disabled by default</b>
+     * If enabled, then the content-type HTTP header will be set using the file extension to determine the type,
+     * <b>disabled by default</b>
+     * This flag is only effective when uploading from a File, not directly from a Stream.
      */
     private static final boolean SET_CONTENT_TYPE_FROM_FILE_EXTENSION =
             Boolean.valueOf( System.getProperty( "maven.wagon.http.file.autocontenttype", "false" ) );

--- a/wagon-providers/wagon-http-shared/src/main/java/org/apache/maven/wagon/shared/http/AbstractHttpClientWagon.java
+++ b/wagon-providers/wagon-http-shared/src/main/java/org/apache/maven/wagon/shared/http/AbstractHttpClientWagon.java
@@ -177,10 +177,9 @@ public abstract class AbstractHttpClientWagon
          */
         private String determineContentType()
         {
-            String mimeType;
             try
             {
-                mimeType = this.source != null
+                String mimeType = this.source != null
                             ? URLConnection.guessContentTypeFromName( this.source.getName() )
                             : this.stream != null
                                 ? URLConnection.guessContentTypeFromStream( this.stream )
@@ -191,14 +190,13 @@ public abstract class AbstractHttpClientWagon
                 {
                     mimeType = DEFAULT_CONTENT_TYPE;
                 }
+                return mimeType;
             }
             catch ( IOException e )
             {
                 // will only occur when guessContentTypeFromStream gets an IOException
-                mimeType = DEFAULT_CONTENT_TYPE;
+                return DEFAULT_CONTENT_TYPE;
             }
-
-            return mimeType;
         }
 
         public Resource getResource()

--- a/wagon-providers/wagon-http-shared/src/main/java/org/apache/maven/wagon/shared/http/AbstractHttpClientWagon.java
+++ b/wagon-providers/wagon-http-shared/src/main/java/org/apache/maven/wagon/shared/http/AbstractHttpClientWagon.java
@@ -334,7 +334,7 @@ public abstract class AbstractHttpClientWagon
 
     /**
      * If enabled, then the content-type HTTP header will be set using the file extension
-     * or the stream header to determine the type, <b>disabled by default</b>
+     * or the stream header to determine the type, <b>enabled by default</b>
      */
     private static final boolean AUTOSET_CONTENT_TYPE =
             Boolean.valueOf( System.getProperty( "maven.wagon.http.autocontenttype", "true" ) );

--- a/wagon-providers/wagon-http-shared/src/main/java/org/apache/maven/wagon/shared/http/AbstractHttpClientWagon.java
+++ b/wagon-providers/wagon-http-shared/src/main/java/org/apache/maven/wagon/shared/http/AbstractHttpClientWagon.java
@@ -82,6 +82,7 @@ import org.apache.maven.wagon.repository.Repository;
 import org.apache.maven.wagon.resource.Resource;
 import org.codehaus.plexus.util.StringUtils;
 
+import javax.activation.MimetypesFileTypeMap;
 import javax.net.ssl.HttpsURLConnection;
 import javax.net.ssl.SSLContext;
 import java.io.Closeable;
@@ -119,6 +120,8 @@ import static org.apache.maven.wagon.shared.http.HttpMessageUtils.formatTransfer
 public abstract class AbstractHttpClientWagon
     extends StreamWagon
 {
+    private static final MimetypesFileTypeMap FILE_TYPE_MAP = new MimetypesFileTypeMap();
+
     final class WagonHttpEntity
         extends AbstractHttpEntity
     {
@@ -142,6 +145,11 @@ public abstract class AbstractHttpClientWagon
             {
                 this.source = source;
                 this.repeatable = true;
+                final String mimeType = FILE_TYPE_MAP.getContentType( source );
+                if ( mimeType != null && !mimeType.isEmpty() )
+                {
+                    setContentType( mimeType );
+                }
             }
             else
             {
@@ -152,6 +160,7 @@ public abstract class AbstractHttpClientWagon
             this.length = resource == null ? -1 : resource.getContentLength();
 
             this.wagon = wagon;
+
         }
 
         public Resource getResource()

--- a/wagon-providers/wagon-http-shared/src/main/java/org/apache/maven/wagon/shared/http/AbstractHttpClientWagon.java
+++ b/wagon-providers/wagon-http-shared/src/main/java/org/apache/maven/wagon/shared/http/AbstractHttpClientWagon.java
@@ -145,12 +145,18 @@ public abstract class AbstractHttpClientWagon
             {
                 this.source = source;
                 this.repeatable = true;
-                final String mimeType = SET_CONTENT_TYPE_FROM_FILE_EXTENSION
-                        ? FILE_TYPE_MAP.getContentType( source )
-                        : null;
-                if ( mimeType != null && !mimeType.isEmpty() )
+                // if the content-type has not been set then
+                // if the option flag is TRUE and the content type is determinable from the file extension
+                // then set it from the file extension
+                if ( getContentType() == null )
                 {
-                    setContentType( mimeType );
+                    final String mimeType = SET_CONTENT_TYPE_FROM_FILE_EXTENSION
+                            ? FILE_TYPE_MAP.getContentType( source )
+                            : null;
+                    if ( mimeType != null && !mimeType.isEmpty() )
+                    {
+                        setContentType( mimeType );
+                    }
                 }
             }
             else


### PR DESCRIPTION
Set the HTTP content-type header, 

- using the file extension to determine value, when uploading a file.

- using the header when uploading a Stream

