### PR TITLE
fix encode URL to preserve trailing slash

### DIFF
--- a/wagon-providers/wagon-http-shared/src/main/java/org/apache/maven/wagon/shared/http/EncodingUtil.java
+++ b/wagon-providers/wagon-http-shared/src/main/java/org/apache/maven/wagon/shared/http/EncodingUtil.java
@@ -92,7 +92,13 @@ public class EncodingUtil
     {
         String[] pathSegments = path == null ? new String[0] : path.split( "/" );
 
-        return encodeURLToString( baseUrl, pathSegments );
+        String encodedUrl = encodeURLToString( baseUrl, pathSegments );
+        if ( path != null && path.endsWith( "/" ) )
+        {
+            return encodedUrl + "/";
+        }
+
+        return encodedUrl;
     }
 
     /**

--- a/wagon-providers/wagon-http-shared/src/test/java/org/apache/maven/wagon/shared/http/EncodingUtilTest.java
+++ b/wagon-providers/wagon-http-shared/src/test/java/org/apache/maven/wagon/shared/http/EncodingUtilTest.java
@@ -25,8 +25,31 @@ import java.net.MalformedURLException;
 import java.net.URISyntaxException;
 
 public class EncodingUtilTest
-    extends TestCase
-{
+        extends TestCase {
+    public void testEncodeURLWithTrailingSlash()
+    {
+        String baseUrl = "https://host:1234/test";
+        String path = "demo.zip/";
+        String expectedUrl = String.format( "%s/%s", baseUrl, path );
+
+        String encodedURL = EncodingUtil.encodeURLToString( baseUrl, path );
+
+        assertEquals( expectedUrl, encodedURL );
+    }
+
+    public void testEncodeUrlApisConsistent()
+    {
+        String baseUrl = "https://host:1234/test";
+        String path = "demo.zip/";
+        String fullUrl = String.format( "%s/%s", baseUrl, path );
+
+        String encodedFullURLToString = EncodingUtil.encodeURLToString( fullUrl );
+        String encodedURLToString = EncodingUtil.encodeURLToString( baseUrl, path );
+
+        assertEquals( encodedFullURLToString, fullUrl );
+        assertEquals( encodedFullURLToString, encodedURLToString );
+    }
+
     public void testEncodeURLWithSpaces()
         throws URISyntaxException, MalformedURLException
     {


### PR DESCRIPTION
In this pull request we have a fix for breaking change introduced by `EncodingUtil.encodeURLToString( String baseUrl, String path )` for URLs with trailing slash in the following commit: https://github.com/apache/maven-wagon/commit/7d1315e47df948d8b17f5c759b20a5b3437cbff7#diff-a0742c473bc4d821caf820463c87956b67da4d07c059d5b6a631e98dd3f7f7b4R93, which has two issues:
- inconsistency between `EncodingUtil.encodeURLToString( String url )` and `EncodingUtil.encodeURLToString( String baseUrl, String path )` in regards to URLs with trailing slash
- affects `org.apache.maven.wagon.shared.http.AbstractHttpClientWagon.resourceExists(...)` API, as URL `https://host:1234/test/demo.zip/` gets normalized to `https://host:1234/test/demo.zip` (with no trailing slash) by `EncodingUtil.encodeURLToString( String baseUrl, String path )` before verify if resource exists