### PR TITLE
Upgrade HttpCore to 4.4.14 and HttpClient to 4.5.13

### DIFF
--- a/wagon-providers/pom.xml
+++ b/wagon-providers/pom.xml
@@ -50,12 +50,12 @@ under the License.
       <dependency>
         <groupId>org.apache.httpcomponents</groupId>
         <artifactId>httpclient</artifactId>
-        <version>4.5.12</version>
+        <version>4.5.13</version>
       </dependency>
       <dependency>
         <groupId>org.apache.httpcomponents</groupId>
         <artifactId>httpcore</artifactId>
-        <version>4.4.13</version>
+        <version>4.4.14</version>
       </dependency>
       <dependency>
         <groupId>org.apache.sshd</groupId>


### PR DESCRIPTION
- get fix for https://issues.apache.org/jira/browse/HTTPCORE-634
  which is causing artifact download failures with error messages such as
  "Could not transfer artifact groupId:artifact:1.2.3 from/to central (https://repo1.maven.org/maven2): Entry [id:1280][route:{s}->https://repo1.maven.org:443][state:null] has not been leased from this pool"