### PR TITLE
[WAGON-607] Upgrade HttpCore to 4.4.14

### DIFF
--- a/wagon-providers/pom.xml
+++ b/wagon-providers/pom.xml
@@ -55,7 +55,7 @@ under the License.
       <dependency>
         <groupId>org.apache.httpcomponents</groupId>
         <artifactId>httpcore</artifactId>
-        <version>4.4.13</version>
+        <version>4.4.14</version>
       </dependency>
       <dependency>
         <groupId>org.apache.sshd</groupId>


### PR DESCRIPTION
Fixes https://issues.apache.org/jira/browse/WAGON-607

- get fix for https://issues.apache.org/jira/browse/HTTPCORE-634
  which is causing artifact download failures with error messages such as `Could not transfer artifact groupId:artifact:1.2.3 from/to central (https://repo1.maven.org/maven2): Entry [id:1280][route:{s}->https://repo1.maven.org:443][state:null] has not been leased from this pool`
