### PR TITLE
Drop findbugs from site reporting

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -571,11 +571,6 @@ under the License.
               </reportSet>
             </reportSets>
           </plugin>
-          <plugin>
-            <groupId>org.codehaus.mojo</groupId>
-            <artifactId>findbugs-maven-plugin</artifactId>
-            <version>3.0.4</version>
-          </plugin>
         </plugins>
       </reporting>
     </profile>


### PR DESCRIPTION
There is used old version of plugin, is the cause of failed build on jdk 17
findbugs was also removed from the latest parent pom MPOM-279