### PR TITLE
[WAGON-627] Maven deploy fails with 401 Unauthorized when using £ in …

### DIFF
--- a/wagon-providers/wagon-http-shared/src/main/java/org/apache/maven/wagon/shared/http/AbstractHttpClientWagon.java
+++ b/wagon-providers/wagon-http-shared/src/main/java/org/apache/maven/wagon/shared/http/AbstractHttpClientWagon.java
@@ -779,7 +779,7 @@ public abstract class AbstractHttpClientWagon
 
         if ( credentialsProvider.getCredentials( targetScope ) != null )
         {
-            BasicScheme targetAuth = new BasicScheme();
+            BasicScheme targetAuth = new BasicScheme( StandardCharsets.UTF_8 );
             authCache.put( targetHost, targetAuth );
         }
 
@@ -978,7 +978,7 @@ public abstract class AbstractHttpClientWagon
 
             if ( credentialsProvider.getCredentials( targetScope ) != null )
             {
-                BasicScheme targetAuth = new BasicScheme();
+                BasicScheme targetAuth = new BasicScheme( StandardCharsets.UTF_8 );
                 authCache.put( targetHost, targetAuth );
             }
         }

--- a/wagon-providers/wagon-webdav-jackrabbit/src/main/java/org/apache/maven/wagon/providers/webdav/WebDavWagon.java
+++ b/wagon-providers/wagon-webdav-jackrabbit/src/main/java/org/apache/maven/wagon/providers/webdav/WebDavWagon.java
@@ -50,6 +50,7 @@ import org.w3c.dom.Node;
 import java.io.File;
 import java.io.IOException;
 import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -165,7 +166,7 @@ public class WebDavWagon
 
         if ( getCredentialsProvider().getCredentials( targetScope ) != null )
         {
-            BasicScheme targetAuth = new BasicScheme();
+            BasicScheme targetAuth = new BasicScheme( StandardCharsets.UTF_8 );
             getAuthCache().put( targetHost, targetAuth );
         }
         HttpMkcol method = new HttpMkcol( url );


### PR DESCRIPTION
…password

When configuring preemptive authentication we need to make sure that it uses
the same character encoding as the custom auth scheme registry. Then characters
are properly encoded into bytes.

This closes #83