### PR TITLE
[WAGON-628] Default connect timeout not set when no HttpMethodConfigu…

### DIFF
--- a/wagon-providers/wagon-http-shared/src/main/java/org/apache/maven/wagon/shared/http/AbstractHttpClientWagon.java
+++ b/wagon-providers/wagon-http-shared/src/main/java/org/apache/maven/wagon/shared/http/AbstractHttpClientWagon.java
@@ -950,20 +950,18 @@ public abstract class AbstractHttpClientWagon
             requestConfigBuilder.setProxy( proxy );
         }
 
-        HttpMethodConfiguration config =
-            httpConfiguration == null ? null : httpConfiguration.getMethodConfiguration( httpMethod );
+        requestConfigBuilder.setConnectTimeout( getTimeout() );
+        requestConfigBuilder.setSocketTimeout( getReadTimeout() );
+        if ( httpMethod instanceof HttpPut )
+        {
+            requestConfigBuilder.setExpectContinueEnabled( true );
+        }
 
+        HttpMethodConfiguration config =
+                httpConfiguration == null ? null : httpConfiguration.getMethodConfiguration( httpMethod );
         if ( config != null )
         {
             ConfigurationUtils.copyConfig( config, requestConfigBuilder );
-        }
-        else
-        {
-            requestConfigBuilder.setSocketTimeout( getReadTimeout() );
-            if ( httpMethod instanceof HttpPut )
-            {
-                requestConfigBuilder.setExpectContinueEnabled( true );
-            }
         }
 
         HttpClientContext localContext = HttpClientContext.create();

--- a/wagon-providers/wagon-http-shared/src/main/java/org/apache/maven/wagon/shared/http/ConfigurationUtils.java
+++ b/wagon-providers/wagon-http-shared/src/main/java/org/apache/maven/wagon/shared/http/ConfigurationUtils.java
@@ -61,14 +61,9 @@ public class ConfigurationUtils
 
     public static void copyConfig( HttpMethodConfiguration config, RequestConfig.Builder builder )
     {
-        if ( config.getConnectionTimeout() > 0 )
-        {
-            builder.setConnectTimeout( config.getConnectionTimeout() );
-        }
-        if ( config.getReadTimeout() > 0 )
-        {
-            builder.setSocketTimeout( config.getReadTimeout() );
-        }
+        builder.setConnectTimeout( config.getConnectionTimeout() );
+        builder.setSocketTimeout( config.getReadTimeout() );
+
         Properties params = config.getParams();
         if ( params != null )
         {

--- a/wagon-providers/wagon-http-shared/src/main/java/org/apache/maven/wagon/shared/http/HttpConfiguration.java
+++ b/wagon-providers/wagon-http-shared/src/main/java/org/apache/maven/wagon/shared/http/HttpConfiguration.java
@@ -19,9 +19,6 @@ package org.apache.maven.wagon.shared.http;
  * under the License.
  */
 
-import org.apache.http.client.methods.HttpGet;
-import org.apache.http.client.methods.HttpHead;
-import org.apache.http.client.methods.HttpPut;
 import org.apache.http.client.methods.HttpUriRequest;
 
 /**
@@ -29,9 +26,6 @@ import org.apache.http.client.methods.HttpUriRequest;
  */
 public class HttpConfiguration
 {
-
-    private static final HttpMethodConfiguration DEFAULT_PUT =
-        new HttpMethodConfiguration().addParam( "http.protocol.expect-continue", "%b,true" );
 
     private HttpMethodConfiguration all;
 
@@ -87,20 +81,17 @@ public class HttpConfiguration
 
     public HttpMethodConfiguration getMethodConfiguration( HttpUriRequest method )
     {
-        if ( method instanceof HttpGet )
+        switch ( method.getMethod() )
         {
+        case "GET":
             return ConfigurationUtils.merge( all, get );
-        }
-        else if ( method instanceof HttpPut )
-        {
-            return ConfigurationUtils.merge( DEFAULT_PUT, all, put );
-        }
-        else if ( method instanceof HttpHead )
-        {
+        case "PUT":
+            return ConfigurationUtils.merge( all, put );
+        case "HEAD":
             return ConfigurationUtils.merge( all, head );
+        default:
+            return all;
         }
-
-        return all;
     }
 
 }


### PR DESCRIPTION
…ration is available

Set first request config values then have every HTTP method separately apply
its config. They can safely overwrite timeouts even with -1 (indefinite).
There is also no need to explicitly set PUT default config because it is always
set before config is applied.

This closes #84