### PR TITLE
[WAGON-632] Java 8

### DIFF
--- a/.github/workflows/maven-verify.yml
+++ b/.github/workflows/maven-verify.yml
@@ -24,4 +24,4 @@ on:
 jobs:
   build:
     name: Verify
-    uses: apache/maven-gh-actions-shared/.github/workflows/maven-verify.yml@v2
+    uses: apache/maven-gh-actions-shared/.github/workflows/maven-verify.yml@v3

--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,7 @@ under the License.
     <maven.test.redirectTestOutputToFile>true</maven.test.redirectTestOutputToFile>
     <slf4jVersion>1.7.36</slf4jVersion>
     <maven.site.path>wagon-archives/wagon-LATEST</maven.site.path>
-    <javaVersion>7</javaVersion>
+    <javaVersion>8</javaVersion>
     <project.build.outputTimestamp>2022-12-18T21:06:44Z</project.build.outputTimestamp>
   </properties>
 

--- a/wagon-provider-api/src/main/java/org/apache/maven/wagon/events/SessionEventSupport.java
+++ b/wagon-provider-api/src/main/java/org/apache/maven/wagon/events/SessionEventSupport.java
@@ -33,7 +33,7 @@ public final class SessionEventSupport
     /**
      * registered listeners
      */
-    private final List<SessionListener> listeners = new ArrayList<SessionListener>();
+    private final List<SessionListener> listeners = new ArrayList<>();
 
     /**
      * Adds the listener to the collection of listeners

--- a/wagon-provider-api/src/main/java/org/apache/maven/wagon/events/TransferEventSupport.java
+++ b/wagon-provider-api/src/main/java/org/apache/maven/wagon/events/TransferEventSupport.java
@@ -35,7 +35,7 @@ public final class TransferEventSupport
     /**
      * registered listeners
      */
-    private final List<TransferListener> listeners = new ArrayList<TransferListener>();
+    private final List<TransferListener> listeners = new ArrayList<>();
 
     /**
      * Adds the listener to the collection of listeners

--- a/wagon-provider-test/src/main/java/org/apache/maven/wagon/WagonTestCase.java
+++ b/wagon-provider-test/src/main/java/org/apache/maven/wagon/WagonTestCase.java
@@ -539,7 +539,7 @@ public abstract class WagonTestCase
 
             wagon.putDirectory( sourceFile, dirName );
 
-            List<String> resourceNames = new ArrayList<String>( resources.length + 1 );
+            List<String> resourceNames = new ArrayList<>( resources.length + 1 );
 
             resourceNames.add( dirName + "/" + resourceToCreate );
             for ( String resource : resources )
@@ -591,7 +591,7 @@ public abstract class WagonTestCase
 
             wagon.putDirectory( sourceFile, "." );
 
-            List<String> resourceNames = new ArrayList<String>( resources.length + 1 );
+            List<String> resourceNames = new ArrayList<>( resources.length + 1 );
 
             resourceNames.add( resourceToCreate );
             Collections.addAll( resourceNames, resources );

--- a/wagon-provider-test/src/main/java/org/apache/maven/wagon/http/HttpWagonTestCase.java
+++ b/wagon-provider-test/src/main/java/org/apache/maven/wagon/http/HttpWagonTestCase.java
@@ -1172,7 +1172,7 @@ public abstract class HttpWagonTestCase
 
         File repositoryDirectory;
 
-        public List<HandlerRequestResponse> handlerRequestResponses = new ArrayList<HandlerRequestResponse>();
+        public List<HandlerRequestResponse> handlerRequestResponses = new ArrayList<>();
 
         RedirectHandler( String reason, int retCode, String redirectUrl, File repositoryDirectory )
         {
@@ -2079,11 +2079,11 @@ public abstract class HttpWagonTestCase
     {
         private final File resourceBase;
 
-        public List<DeployedResource> deployedResources = new ArrayList<DeployedResource>();
+        public List<DeployedResource> deployedResources = new ArrayList<>();
 
         public int putCallNumber = 0;
 
-        public List<HandlerRequestResponse> handlerRequestResponses = new ArrayList<HandlerRequestResponse>();
+        public List<HandlerRequestResponse> handlerRequestResponses = new ArrayList<>();
 
         public PutHandler( File repositoryDirectory )
         {
@@ -2140,7 +2140,7 @@ public abstract class HttpWagonTestCase
         extends TestHeaderHandler
     {
 
-        List<HandlerRequestResponse> handlerRequestResponses = new ArrayList<HandlerRequestResponse>();
+        List<HandlerRequestResponse> handlerRequestResponses = new ArrayList<>();
 
         public void handle( String target, Request baseRequest, HttpServletRequest request,
             HttpServletResponse response ) throws IOException, ServletException
@@ -2173,7 +2173,7 @@ public abstract class HttpWagonTestCase
     {
         public Map<String, String> headers = Collections.emptyMap();
 
-        public List<HandlerRequestResponse> handlerRequestResponses = new ArrayList<HandlerRequestResponse>();
+        public List<HandlerRequestResponse> handlerRequestResponses = new ArrayList<>();
 
         TestHeaderHandler()
         {
@@ -2182,7 +2182,7 @@ public abstract class HttpWagonTestCase
         public void handle( String target, Request baseRrequest, HttpServletRequest request,
             HttpServletResponse response ) throws IOException, ServletException
         {
-            headers = new HashMap<String, String>();
+            headers = new HashMap<>();
             for ( Enumeration<String> e = baseRrequest.getHeaderNames(); e.hasMoreElements(); )
             {
                 String name = e.nextElement();
@@ -2243,7 +2243,7 @@ public abstract class HttpWagonTestCase
         extends ConstraintSecurityHandler
     {
 
-        public List<HandlerRequestResponse> handlerRequestResponses = new ArrayList<HandlerRequestResponse>();
+        public List<HandlerRequestResponse> handlerRequestResponses = new ArrayList<>();
 
         @Override
         public void handle( String target, Request baseRequest, HttpServletRequest request,

--- a/wagon-providers/wagon-file/src/main/java/org/apache/maven/wagon/providers/file/FileWagon.java
+++ b/wagon-providers/wagon-file/src/main/java/org/apache/maven/wagon/providers/file/FileWagon.java
@@ -240,7 +240,7 @@ public class FileWagon
 
         File[] files = path.listFiles();
 
-        List<String> list = new ArrayList<String>( files.length );
+        List<String> list = new ArrayList<>( files.length );
         for ( File file : files )
         {
             String name = file.getName();

--- a/wagon-providers/wagon-ftp/src/main/java/org/apache/maven/wagon/providers/ftp/FtpWagon.java
+++ b/wagon-providers/wagon-ftp/src/main/java/org/apache/maven/wagon/providers/ftp/FtpWagon.java
@@ -466,7 +466,7 @@ public class FtpWagon
                 throw new ResourceDoesNotExistException( "Could not find file: '" + resource + "'" );
             }
 
-            List<String> ret = new ArrayList<String>();
+            List<String> ret = new ArrayList<>();
             for ( FTPFile file : ftpFiles )
             {
                 String name = file.getName();

--- a/wagon-providers/wagon-ftp/src/test/java/org/apache/maven/wagon/providers/ftp/FtpWagonTest.java
+++ b/wagon-providers/wagon-ftp/src/test/java/org/apache/maven/wagon/providers/ftp/FtpWagonTest.java
@@ -90,7 +90,7 @@ public class FtpWagonTest
             user.setName("admin");
             user.setPassword("admin");
 
-            List<Authority> authorities = new ArrayList<Authority>();
+            List<Authority> authorities = new ArrayList<>();
             authorities.add( new WritePermission() );
 
             user.setAuthorities( authorities );

--- a/wagon-providers/wagon-http-lightweight/src/main/java/org/apache/maven/wagon/providers/http/LightweightHttpWagonAuthenticator.java
+++ b/wagon-providers/wagon-http-lightweight/src/main/java/org/apache/maven/wagon/providers/http/LightweightHttpWagonAuthenticator.java
@@ -29,7 +29,7 @@ import java.net.PasswordAuthentication;
 public class LightweightHttpWagonAuthenticator
     extends Authenticator
 {
-    ThreadLocal<LightweightHttpWagon> localWagon = new ThreadLocal<LightweightHttpWagon>();
+    ThreadLocal<LightweightHttpWagon> localWagon = new ThreadLocal<>();
 
     protected PasswordAuthentication getPasswordAuthentication()
     {

--- a/wagon-providers/wagon-scm/src/main/java/org/apache/maven/wagon/providers/scm/ScmWagon.java
+++ b/wagon-providers/wagon-scm/src/main/java/org/apache/maven/wagon/providers/scm/ScmWagon.java
@@ -509,7 +509,7 @@ public class ScmWagon
         String res =
             partCOSubdir.length() >= targetName.length() ? "" : targetName.substring( partCOSubdir.length() ) + '/';
 
-        ArrayList<File> createdDirs = new ArrayList<File>();
+        ArrayList<File> createdDirs = new ArrayList<>();
         File deepDir = new File( checkoutDirectory, res );
 
         boolean added = false;
@@ -842,7 +842,7 @@ public class ScmWagon
                 throw new ResourceDoesNotExistException( result.getProviderMessage() );
             }
 
-            List<String> files = new ArrayList<String>();
+            List<String> files = new ArrayList<>();
 
             for ( ScmFile f : result.getFiles() )
             {

--- a/wagon-providers/wagon-ssh-common-test/src/main/java/org/apache/maven/wagon/providers/ssh/ScpCommandFactory.java
+++ b/wagon-providers/wagon-ssh-common-test/src/main/java/org/apache/maven/wagon/providers/ssh/ScpCommandFactory.java
@@ -82,7 +82,7 @@ public class ScpCommandFactory
         }
 
         String[] args = command.split( " " );
-        List<String> parts = new ArrayList<String>();
+        List<String> parts = new ArrayList<>();
         parts.add( args[0] );
         for ( int i = 1; i < args.length; i++ )
         {

--- a/wagon-providers/wagon-ssh-common-test/src/main/java/org/apache/maven/wagon/providers/ssh/SshServerEmbedded.java
+++ b/wagon-providers/wagon-ssh-common-test/src/main/java/org/apache/maven/wagon/providers/ssh/SshServerEmbedded.java
@@ -54,7 +54,7 @@ public class SshServerEmbedded
 
     private SshServer sshd;
 
-    private List<String> sshKeysResources = new ArrayList<String>();
+    private List<String> sshKeysResources = new ArrayList<>();
 
     private TestPublickeyAuthenticator publickeyAuthenticator;
 

--- a/wagon-providers/wagon-ssh-common-test/src/main/java/org/apache/maven/wagon/providers/ssh/TestPasswordAuthenticator.java
+++ b/wagon-providers/wagon-ssh-common-test/src/main/java/org/apache/maven/wagon/providers/ssh/TestPasswordAuthenticator.java
@@ -33,7 +33,7 @@ public class TestPasswordAuthenticator
     implements PasswordAuthenticator
 {
     List<PasswordAuthenticatorRequest> requests =
-        new ArrayList<PasswordAuthenticatorRequest>();
+        new ArrayList<>();
 
     public boolean authenticate( String username, String password, ServerSession session )
     {

--- a/wagon-providers/wagon-ssh-common-test/src/main/java/org/apache/maven/wagon/providers/ssh/TestPublickeyAuthenticator.java
+++ b/wagon-providers/wagon-ssh-common-test/src/main/java/org/apache/maven/wagon/providers/ssh/TestPublickeyAuthenticator.java
@@ -43,7 +43,7 @@ public class TestPublickeyAuthenticator
     implements PublickeyAuthenticator
 {
     private List<PublickeyAuthenticatorRequest> publickeyAuthenticatorRequests =
-        new ArrayList<PublickeyAuthenticatorRequest>();
+        new ArrayList<>();
 
     private boolean keyAuthz;
 

--- a/wagon-providers/wagon-ssh-common/src/main/java/org/apache/maven/wagon/providers/ssh/LSParser.java
+++ b/wagon-providers/wagon-ssh-common/src/main/java/org/apache/maven/wagon/providers/ssh/LSParser.java
@@ -67,7 +67,7 @@ public class LSParser
     public List<String> parseFiles( String rawLS )
         throws TransferFailedException
     {
-        List<String> ret = new ArrayList<String>();
+        List<String> ret = new ArrayList<>();
         try
         {
             BufferedReader br = new BufferedReader( new StringReader( rawLS ) );

--- a/wagon-providers/wagon-ssh-common/src/main/java/org/apache/maven/wagon/providers/ssh/knownhost/AbstractKnownHostsProvider.java
+++ b/wagon-providers/wagon-ssh-common/src/main/java/org/apache/maven/wagon/providers/ssh/knownhost/AbstractKnownHostsProvider.java
@@ -44,7 +44,7 @@ public abstract class AbstractKnownHostsProvider
      */
     protected String contents;
 
-    protected Set<KnownHostEntry> knownHosts = new HashSet<KnownHostEntry>();
+    protected Set<KnownHostEntry> knownHosts = new HashSet<>();
 
     public void setHostKeyChecking( String hostKeyChecking )
     {

--- a/wagon-providers/wagon-ssh-common/src/main/java/org/apache/maven/wagon/providers/ssh/knownhost/StreamKnownHostsProvider.java
+++ b/wagon-providers/wagon-ssh-common/src/main/java/org/apache/maven/wagon/providers/ssh/knownhost/StreamKnownHostsProvider.java
@@ -64,7 +64,7 @@ public class StreamKnownHostsProvider
     protected Set<KnownHostEntry> loadKnownHosts( String contents )
         throws IOException
     {
-        Set<KnownHostEntry> hosts = new HashSet<KnownHostEntry>();
+        Set<KnownHostEntry> hosts = new HashSet<>();
         
         BufferedReader br = new BufferedReader( new StringReader( contents ) );
         

--- a/wagon-providers/wagon-ssh/src/main/java/org/apache/maven/wagon/providers/ssh/jsch/SftpWagon.java
+++ b/wagon-providers/wagon-ssh/src/main/java/org/apache/maven/wagon/providers/ssh/jsch/SftpWagon.java
@@ -373,7 +373,7 @@ public class SftpWagon
 
             @SuppressWarnings( "unchecked" )
             List<ChannelSftp.LsEntry> fileList = channel.ls( filename );
-            List<String> files = new ArrayList<String>( fileList.size() );
+            List<String> files = new ArrayList<>( fileList.size() );
             for ( ChannelSftp.LsEntry entry : fileList )
             {
                 String name = entry.getFilename();

--- a/wagon-providers/wagon-webdav-jackrabbit/src/main/java/org/apache/jackrabbit/webdav/MultiStatus.java
+++ b/wagon-providers/wagon-webdav-jackrabbit/src/main/java/org/apache/jackrabbit/webdav/MultiStatus.java
@@ -41,7 +41,7 @@ public class MultiStatus
      * Map collecting the responses for this multistatus, where every href must
      * only occur one single time.
      */
-    private Map<String, MultiStatusResponse> responses = new LinkedHashMap<String, MultiStatusResponse>();
+    private Map<String, MultiStatusResponse> responses = new LinkedHashMap<>();
 
     /**
      * A general response description at the multistatus top level is used to

--- a/wagon-tcks/wagon-tck-http/src/main/java/org/apache/maven/wagon/tck/http/HttpWagonTests.java
+++ b/wagon-tcks/wagon-tck-http/src/main/java/org/apache/maven/wagon/tck/http/HttpWagonTests.java
@@ -61,11 +61,11 @@ public abstract class HttpWagonTests
 
     private String baseUrl;
 
-    private static final Set<File> TMP_FILES = new HashSet<File>();
+    private static final Set<File> TMP_FILES = new HashSet<>();
 
     private Repository repo;
 
-    private final Set<Object> notificationTargets = new HashSet<Object>();
+    private final Set<Object> notificationTargets = new HashSet<>();
 
     // CHECKSTYLE_OFF: ConstantName
     protected static final Logger logger = LoggerFactory.getLogger( HttpWagonTests.class );

--- a/wagon-tcks/wagon-tck-http/src/main/java/org/apache/maven/wagon/tck/http/util/TestUtil.java
+++ b/wagon-tcks/wagon-tck-http/src/main/java/org/apache/maven/wagon/tck/http/util/TestUtil.java
@@ -46,7 +46,7 @@ public final class TestUtil
     private static final Logger logger = LoggerFactory.getLogger( TestUtil.class );
     // CHECKSTYLE_ON: ConstantName
 
-    private static final Map<String, File> BASES = new HashMap<String, File>();
+    private static final Map<String, File> BASES = new HashMap<>();
 
     private TestUtil()
     {


### PR DESCRIPTION
If there's a reason we can't move to Java 8, we can perhaps use Files.copy instead of plexus to copy the directory in FileWagon. Might want to do that anyway. Bugs there seem to be at the root of more than one CI failure. 