### PR TITLE
[MNG-6829] Replace any StringUtils#isEmpty(String) and #isNotEmpty(String)

### DIFF
--- a/wagon-provider-test/src/main/java/org/apache/maven/wagon/http/HttpWagonTestCase.java
+++ b/wagon-provider-test/src/main/java/org/apache/maven/wagon/http/HttpWagonTestCase.java
@@ -936,7 +936,7 @@ public abstract class HttpWagonTestCase
         {
             for ( int i = 0; i < expectedResponseCodes.length; i++ )
             {
-                success &= ( expectedResponseCodes[i] == handlerRequestResponses.get( i ).responseCode );
+                success &= expectedResponseCodes[i] == handlerRequestResponses.get( i ).responseCode;
             }
         }
 
@@ -2317,7 +2317,7 @@ public abstract class HttpWagonTestCase
                     // TODO: add test for 410: Gone?
                     assertTrue( "404 not found response should throw ResourceDoesNotExistException",
                             e instanceof ResourceDoesNotExistException );
-                    reasonPhrase = StringUtils.isEmpty( forReasonPhrase ) ? " Not Found" : ( " " + forReasonPhrase );
+                    reasonPhrase = (forReasonPhrase == null || forReasonPhrase.isEmpty()) ? " Not Found" : ( " " + forReasonPhrase );
                     assertEquals( assertMessageForBadMessage, "resource missing at " + forUrl + ", status: 404"
                             + reasonPhrase, e.getMessage() );
                     break;
@@ -2328,7 +2328,7 @@ public abstract class HttpWagonTestCase
                                     + " AuthenticationException is not explicitly declared as thrown from wagon "
                                     + "methods",
                             e instanceof AuthorizationException );
-                    reasonPhrase = StringUtils.isEmpty( forReasonPhrase ) ? " Unauthorized" : ( " " + forReasonPhrase );
+                    reasonPhrase = (forReasonPhrase == null || forReasonPhrase.isEmpty()) ? " Unauthorized" : ( " " + forReasonPhrase );
                     assertEquals( assertMessageForBadMessage, "authentication failed for " + forUrl + ", status: 401"
                             + reasonPhrase, e.getMessage() );
                     break;
@@ -2336,7 +2336,7 @@ public abstract class HttpWagonTestCase
                 case HttpServletResponse.SC_PROXY_AUTHENTICATION_REQUIRED:
                     assertTrue( "407 Proxy authentication required should throw AuthorizationException",
                             e instanceof AuthorizationException );
-                    reasonPhrase = StringUtils.isEmpty( forReasonPhrase ) ? " Proxy Authentication Required"
+                    reasonPhrase = (forReasonPhrase == null || forReasonPhrase.isEmpty()) ? " Proxy Authentication Required"
                             : ( " " + forReasonPhrase );
                     assertEquals( assertMessageForBadMessage, "proxy authentication failed for "
                             + forUrl + ", status: 407" + reasonPhrase, e.getMessage() );
@@ -2345,7 +2345,7 @@ public abstract class HttpWagonTestCase
                 case HttpServletResponse.SC_FORBIDDEN:
                     assertTrue( "403 Forbidden should throw AuthorizationException",
                             e instanceof AuthorizationException );
-                    reasonPhrase = StringUtils.isEmpty( forReasonPhrase ) ? " Forbidden" : ( " " + forReasonPhrase );
+                    reasonPhrase = (forReasonPhrase == null || forReasonPhrase.isEmpty()) ? " Forbidden" : ( " " + forReasonPhrase );
                     assertEquals( assertMessageForBadMessage, "authorization failed for " + forUrl + ", status: 403"
                             + reasonPhrase, e.getMessage() );
                     break;

--- a/wagon-provider-test/src/main/java/org/apache/maven/wagon/http/HttpWagonTestCase.java
+++ b/wagon-provider-test/src/main/java/org/apache/maven/wagon/http/HttpWagonTestCase.java
@@ -2317,7 +2317,8 @@ public abstract class HttpWagonTestCase
                     // TODO: add test for 410: Gone?
                     assertTrue( "404 not found response should throw ResourceDoesNotExistException",
                             e instanceof ResourceDoesNotExistException );
-                    reasonPhrase = (forReasonPhrase == null || forReasonPhrase.isEmpty()) ? " Not Found" : ( " " + forReasonPhrase );
+                    reasonPhrase = ( forReasonPhrase == null || forReasonPhrase.isEmpty() )
+                            ? " Not Found" : ( " " + forReasonPhrase );
                     assertEquals( assertMessageForBadMessage, "resource missing at " + forUrl + ", status: 404"
                             + reasonPhrase, e.getMessage() );
                     break;
@@ -2328,7 +2329,8 @@ public abstract class HttpWagonTestCase
                                     + " AuthenticationException is not explicitly declared as thrown from wagon "
                                     + "methods",
                             e instanceof AuthorizationException );
-                    reasonPhrase = (forReasonPhrase == null || forReasonPhrase.isEmpty()) ? " Unauthorized" : ( " " + forReasonPhrase );
+                    reasonPhrase = ( forReasonPhrase == null || forReasonPhrase.isEmpty() )
+                            ? " Unauthorized" : ( " " + forReasonPhrase );
                     assertEquals( assertMessageForBadMessage, "authentication failed for " + forUrl + ", status: 401"
                             + reasonPhrase, e.getMessage() );
                     break;
@@ -2336,8 +2338,8 @@ public abstract class HttpWagonTestCase
                 case HttpServletResponse.SC_PROXY_AUTHENTICATION_REQUIRED:
                     assertTrue( "407 Proxy authentication required should throw AuthorizationException",
                             e instanceof AuthorizationException );
-                    reasonPhrase = (forReasonPhrase == null || forReasonPhrase.isEmpty()) ? " Proxy Authentication Required"
-                            : ( " " + forReasonPhrase );
+                    reasonPhrase = ( forReasonPhrase == null || forReasonPhrase.isEmpty() )
+                            ? " Proxy Authentication Required" : ( " " + forReasonPhrase );
                     assertEquals( assertMessageForBadMessage, "proxy authentication failed for "
                             + forUrl + ", status: 407" + reasonPhrase, e.getMessage() );
                     break;
@@ -2345,7 +2347,8 @@ public abstract class HttpWagonTestCase
                 case HttpServletResponse.SC_FORBIDDEN:
                     assertTrue( "403 Forbidden should throw AuthorizationException",
                             e instanceof AuthorizationException );
-                    reasonPhrase = (forReasonPhrase == null || forReasonPhrase.isEmpty()) ? " Forbidden" : ( " " + forReasonPhrase );
+                    reasonPhrase = ( forReasonPhrase == null || forReasonPhrase.isEmpty() )
+                            ? " Forbidden" : ( " " + forReasonPhrase );
                     assertEquals( assertMessageForBadMessage, "authorization failed for " + forUrl + ", status: 403"
                             + reasonPhrase, e.getMessage() );
                     break;

--- a/wagon-providers/wagon-http-lightweight/src/test/java/org/apache/maven/wagon/providers/http/LightweightHttpWagonTest.java
+++ b/wagon-providers/wagon-http-lightweight/src/test/java/org/apache/maven/wagon/providers/http/LightweightHttpWagonTest.java
@@ -25,7 +25,6 @@ import org.apache.maven.wagon.TransferFailedException;
 import org.apache.maven.wagon.WagonException;
 import org.apache.maven.wagon.authorization.AuthorizationException;
 import org.apache.maven.wagon.http.HttpWagonTestCase;
-import org.codehaus.plexus.util.StringUtils;
 
 import javax.servlet.http.HttpServletResponse;
 import java.io.FileNotFoundException;
@@ -114,7 +113,7 @@ public class LightweightHttpWagonTest
                             e instanceof AuthorizationException );
 
                     assertEquals( assertMessageForBadMessage, "authorization failed for " + forUrl + ", status: 403"
-                            + ( StringUtils.isEmpty( forReasonPhrase ) ? " Forbidden" : ( " " + forReasonPhrase ) ),
+                            + ( (forReasonPhrase == null || forReasonPhrase.isEmpty()) ? " Forbidden" : ( " " + forReasonPhrase ) ),
                             e.getMessage() );
                     break;
 
@@ -123,7 +122,7 @@ public class LightweightHttpWagonTest
                             e instanceof AuthorizationException );
 
                     assertEquals( assertMessageForBadMessage, "authentication failed for " + forUrl + ", status: 401"
-                                    + ( StringUtils.isEmpty( forReasonPhrase ) ? " Unauthorized" :
+                                    + ( (forReasonPhrase == null || forReasonPhrase.isEmpty()) ? " Unauthorized" :
                                     ( " " + forReasonPhrase ) ),
                             e.getMessage() );
                     break;

--- a/wagon-providers/wagon-http-shared/src/main/java/org/apache/maven/wagon/shared/http/AbstractHttpClientWagon.java
+++ b/wagon-providers/wagon-http-shared/src/main/java/org/apache/maven/wagon/shared/http/AbstractHttpClientWagon.java
@@ -605,7 +605,7 @@ public abstract class AbstractHttpClientWagon
             String username = authenticationInfo.getUserName();
             String password = authenticationInfo.getPassword();
 
-            if ( (username != null && !username.isEmpty()) && (password != null && !password.isEmpty()) )
+            if ( ( username != null && !username.isEmpty() ) && ( password != null && !password.isEmpty() ) )
             {
                 Credentials creds = new UsernamePasswordCredentials( username, password );
 

--- a/wagon-providers/wagon-http-shared/src/main/java/org/apache/maven/wagon/shared/http/AbstractHttpClientWagon.java
+++ b/wagon-providers/wagon-http-shared/src/main/java/org/apache/maven/wagon/shared/http/AbstractHttpClientWagon.java
@@ -80,7 +80,6 @@ import org.apache.maven.wagon.events.TransferEvent;
 import org.apache.maven.wagon.proxy.ProxyInfo;
 import org.apache.maven.wagon.repository.Repository;
 import org.apache.maven.wagon.resource.Resource;
-import org.codehaus.plexus.util.StringUtils;
 
 import javax.net.ssl.HttpsURLConnection;
 import javax.net.ssl.SSLContext;
@@ -448,7 +447,7 @@ public abstract class AbstractHttpClientWagon
         switch ( RETRY_HANDLER_CLASS )
         {
             case "default":
-                if ( StringUtils.isEmpty( RETRY_HANDLER_EXCEPTIONS ) )
+                if ( RETRY_HANDLER_EXCEPTIONS == null || RETRY_HANDLER_EXCEPTIONS.isEmpty() )
                 {
                     return new DefaultHttpRequestRetryHandler(
                             RETRY_HANDLER_COUNT, RETRY_HANDLER_REQUEST_SENT_ENABLED );
@@ -606,7 +605,7 @@ public abstract class AbstractHttpClientWagon
             String username = authenticationInfo.getUserName();
             String password = authenticationInfo.getPassword();
 
-            if ( StringUtils.isNotEmpty( username ) && StringUtils.isNotEmpty( password ) )
+            if ( (username != null && !username.isEmpty()) && (password != null && !password.isEmpty()) )
             {
                 Credentials creds = new UsernamePasswordCredentials( username, password );
 

--- a/wagon-providers/wagon-http-shared/src/main/java/org/apache/maven/wagon/shared/http/HttpMessageUtils.java
+++ b/wagon-providers/wagon-http-shared/src/main/java/org/apache/maven/wagon/shared/http/HttpMessageUtils.java
@@ -25,7 +25,6 @@ import org.apache.maven.wagon.ResourceDoesNotExistException;
 import org.apache.maven.wagon.TransferFailedException;
 import org.apache.maven.wagon.authorization.AuthorizationException;
 import org.apache.maven.wagon.proxy.ProxyInfo;
-import org.codehaus.plexus.util.StringUtils;
 
 /**
  * Helper for HTTP related messages.
@@ -88,7 +87,7 @@ public class HttpMessageUtils
         if ( statusCode != UNKNOWN_STATUS_CODE )
         {
             msg += " -- status code: " + statusCode;
-            if ( StringUtils.isNotEmpty( reasonPhrase ) )
+            if ( reasonPhrase != null && !reasonPhrase.isEmpty() )
             {
                 msg += ", reason phrase: " + reasonPhrase;
             }
@@ -195,7 +194,7 @@ public class HttpMessageUtils
         {
             msg += ", status: " + statusCode;
 
-            if ( StringUtils.isNotEmpty( reasonPhrase ) )
+            if ( reasonPhrase != null && !reasonPhrase.isEmpty() )
             {
                 msg += " " + reasonPhrase;
             }

--- a/wagon-providers/wagon-scm/src/main/java/org/apache/maven/wagon/providers/scm/ScmWagon.java
+++ b/wagon-providers/wagon-scm/src/main/java/org/apache/maven/wagon/providers/scm/ScmWagon.java
@@ -313,12 +313,12 @@ public class ScmWagon
 
         ScmProviderRepository providerRepository = scmRepository.getProviderRepository();
 
-        if ( StringUtils.isNotEmpty( username ) )
+        if ( username != null && !username.isEmpty() )
         {
             providerRepository.setUser( username );
         }
 
-        if ( StringUtils.isNotEmpty( password ) )
+        if ( password != null && !password.isEmpty() )
         {
             providerRepository.setPassword( password );
         }
@@ -327,12 +327,12 @@ public class ScmWagon
         {
             ScmProviderRepositoryWithHost providerRepo = (ScmProviderRepositoryWithHost) providerRepository;
 
-            if ( StringUtils.isNotEmpty( privateKey ) )
+            if ( privateKey != null && !privateKey.isEmpty() )
             {
                 providerRepo.setPrivateKey( privateKey );
             }
 
-            if ( StringUtils.isNotEmpty( passphrase ) )
+            if ( passphrase != null && !passphrase.isEmpty() )
             {
                 providerRepo.setPassphrase( passphrase );
             }
@@ -648,13 +648,13 @@ public class ScmWagon
     private boolean supportsPartialCheckout( ScmProvider scmProvider )
     {
         String scmType = scmProvider.getScmType();
-        return ( "svn".equals( scmType ) || "cvs".equals( scmType ) );
+        return "svn".equals( scmType ) || "cvs".equals( scmType );
     }
 
     private boolean isAlwaysRecursive( ScmProvider scmProvider )
     {
         String scmType = scmProvider.getScmType();
-        return ( "git".equals( scmType ) || "cvs".equals( scmType ) );
+        return "git".equals( scmType ) || "cvs".equals( scmType );
     }
 
     public void putDirectory( File sourceDirectory, String destinationDirectory )

--- a/wagon-providers/wagon-webdav-jackrabbit/src/main/java/org/apache/maven/wagon/providers/webdav/WebDavWagon.java
+++ b/wagon-providers/wagon-webdav-jackrabbit/src/main/java/org/apache/maven/wagon/providers/webdav/WebDavWagon.java
@@ -280,7 +280,7 @@ public class WebDavWagon
                             fileName = PathUtils.filename( PathUtils.dirname( URLDecoder.decode( entryUrl ) ) ) + "/";
                         }
 
-                        if ( !(fileName == null || fileName.isEmpty()) )
+                        if ( !( fileName == null || fileName.isEmpty() ) )
                         {
                             dirs.add( fileName );
                         }

--- a/wagon-providers/wagon-webdav-jackrabbit/src/main/java/org/apache/maven/wagon/providers/webdav/WebDavWagon.java
+++ b/wagon-providers/wagon-webdav-jackrabbit/src/main/java/org/apache/maven/wagon/providers/webdav/WebDavWagon.java
@@ -41,7 +41,6 @@ import org.apache.maven.wagon.authorization.AuthorizationException;
 import org.apache.maven.wagon.repository.Repository;
 import org.apache.maven.wagon.shared.http.AbstractHttpClientWagon;
 import org.codehaus.plexus.util.FileUtils;
-import org.codehaus.plexus.util.StringUtils;
 import org.w3c.dom.Node;
 
 import java.io.File;
@@ -281,7 +280,7 @@ public class WebDavWagon
                             fileName = PathUtils.filename( PathUtils.dirname( URLDecoder.decode( entryUrl ) ) ) + "/";
                         }
 
-                        if ( !StringUtils.isEmpty( fileName ) )
+                        if ( !(fileName == null || fileName.isEmpty()) )
                         {
                             dirs.add( fileName );
                         }

--- a/wagon-tcks/wagon-tck-http/src/main/java/org/apache/maven/wagon/tck/http/Assertions.java
+++ b/wagon-tcks/wagon-tck-http/src/main/java/org/apache/maven/wagon/tck/http/Assertions.java
@@ -25,7 +25,6 @@ import org.apache.maven.wagon.WagonException;
 import org.apache.maven.wagon.authorization.AuthorizationException;
 import org.apache.maven.wagon.proxy.ProxyInfo;
 import org.codehaus.plexus.util.IOUtil;
-import org.codehaus.plexus.util.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -118,7 +117,7 @@ public final class Assertions
                     // TODO: add test for 410: Gone?
                     assertTrue( "404 not found response should throw ResourceDoesNotExistException",
                             e instanceof ResourceDoesNotExistException );
-                    reasonPhrase = StringUtils.isEmpty( forReasonPhrase ) ? " Not Found" : ( " " + forReasonPhrase );
+                    reasonPhrase = (forReasonPhrase == null || forReasonPhrase.isEmpty()) ? " Not Found" : ( " " + forReasonPhrase );
                     assertEquals( assertMessageForBadMessage, "resource missing at " + forUrl + ", status: 404"
                             + reasonPhrase, e.getMessage() );
                     break;
@@ -129,7 +128,7 @@ public final class Assertions
                                     + " AuthenticationException is not explicitly declared as thrown from wagon "
                                     + "methods",
                             e instanceof AuthorizationException );
-                    reasonPhrase = StringUtils.isEmpty( forReasonPhrase ) ? " Unauthorized" : ( " " + forReasonPhrase );
+                    reasonPhrase = (forReasonPhrase == null || forReasonPhrase.isEmpty()) ? " Unauthorized" : ( " " + forReasonPhrase );
                     assertEquals( assertMessageForBadMessage, "authentication failed for " + forUrl + ", status: 401"
                             + reasonPhrase, e.getMessage() );
                     break;
@@ -137,7 +136,7 @@ public final class Assertions
                 case HttpServletResponse.SC_PROXY_AUTHENTICATION_REQUIRED:
                     assertTrue( "407 Proxy authentication required should throw AuthorizationException",
                             e instanceof AuthorizationException );
-                    reasonPhrase = StringUtils.isEmpty( forReasonPhrase ) ? " Proxy Authentication Required"
+                    reasonPhrase = (forReasonPhrase == null || forReasonPhrase.isEmpty()) ? " Proxy Authentication Required"
                             : ( " " + forReasonPhrase );
                     assertEquals( assertMessageForBadMessage, "proxy authentication failed for "
                             + forUrl + ", status: 407" + reasonPhrase, e.getMessage() );
@@ -146,7 +145,7 @@ public final class Assertions
                 case HttpServletResponse.SC_FORBIDDEN:
                     assertTrue( "403 Forbidden should throw AuthorizationException",
                             e instanceof AuthorizationException );
-                    reasonPhrase = StringUtils.isEmpty( forReasonPhrase ) ? " Forbidden" : ( " " + forReasonPhrase );
+                    reasonPhrase = (forReasonPhrase == null || forReasonPhrase.isEmpty()) ? " Forbidden" : ( " " + forReasonPhrase );
                     assertEquals( assertMessageForBadMessage, "authorization failed for " + forUrl + ", status: 403"
                             + reasonPhrase, e.getMessage() );
                     break;

--- a/wagon-tcks/wagon-tck-http/src/main/java/org/apache/maven/wagon/tck/http/Assertions.java
+++ b/wagon-tcks/wagon-tck-http/src/main/java/org/apache/maven/wagon/tck/http/Assertions.java
@@ -117,7 +117,8 @@ public final class Assertions
                     // TODO: add test for 410: Gone?
                     assertTrue( "404 not found response should throw ResourceDoesNotExistException",
                             e instanceof ResourceDoesNotExistException );
-                    reasonPhrase = (forReasonPhrase == null || forReasonPhrase.isEmpty()) ? " Not Found" : ( " " + forReasonPhrase );
+                    reasonPhrase = ( forReasonPhrase == null || forReasonPhrase.isEmpty() )
+                            ? " Not Found" : ( " " + forReasonPhrase );
                     assertEquals( assertMessageForBadMessage, "resource missing at " + forUrl + ", status: 404"
                             + reasonPhrase, e.getMessage() );
                     break;
@@ -128,7 +129,8 @@ public final class Assertions
                                     + " AuthenticationException is not explicitly declared as thrown from wagon "
                                     + "methods",
                             e instanceof AuthorizationException );
-                    reasonPhrase = (forReasonPhrase == null || forReasonPhrase.isEmpty()) ? " Unauthorized" : ( " " + forReasonPhrase );
+                    reasonPhrase = ( forReasonPhrase == null || forReasonPhrase.isEmpty() )
+                            ? " Unauthorized" : ( " " + forReasonPhrase );
                     assertEquals( assertMessageForBadMessage, "authentication failed for " + forUrl + ", status: 401"
                             + reasonPhrase, e.getMessage() );
                     break;
@@ -136,7 +138,9 @@ public final class Assertions
                 case HttpServletResponse.SC_PROXY_AUTHENTICATION_REQUIRED:
                     assertTrue( "407 Proxy authentication required should throw AuthorizationException",
                             e instanceof AuthorizationException );
-                    reasonPhrase = (forReasonPhrase == null || forReasonPhrase.isEmpty()) ? " Proxy Authentication Required"
+                    reasonPhrase = ( forReasonPhrase == null || forReasonPhrase.isEmpty() )
+
+                            ? " Proxy Authentication Required"
                             : ( " " + forReasonPhrase );
                     assertEquals( assertMessageForBadMessage, "proxy authentication failed for "
                             + forUrl + ", status: 407" + reasonPhrase, e.getMessage() );
@@ -145,7 +149,8 @@ public final class Assertions
                 case HttpServletResponse.SC_FORBIDDEN:
                     assertTrue( "403 Forbidden should throw AuthorizationException",
                             e instanceof AuthorizationException );
-                    reasonPhrase = (forReasonPhrase == null || forReasonPhrase.isEmpty()) ? " Forbidden" : ( " " + forReasonPhrase );
+                    reasonPhrase = ( forReasonPhrase == null || forReasonPhrase.isEmpty() )
+                            ? " Forbidden" : ( " " + forReasonPhrase );
                     assertEquals( assertMessageForBadMessage, "authorization failed for " + forUrl + ", status: 403"
                             + reasonPhrase, e.getMessage() );
                     break;


### PR DESCRIPTION
Continuation of https://issues.apache.org/jira/browse/MNG-6829

Review requested of @elharo

Use this link to re-run the recipe: https://public.moderne.io/recipes/org.openrewrite.java.migrate.apache.commons.lang.IsNotEmptyToJdk?organizationId=QXBhY2hlIE1hdmVu