### PR TITLE
[WAGON-643] fix IPv6 URLs

### DIFF
--- a/wagon-provider-api/src/test/java/org/apache/maven/wagon/repository/RepositoryTest.java
+++ b/wagon-provider-api/src/test/java/org/apache/maven/wagon/repository/RepositoryTest.java
@@ -96,36 +96,36 @@ public class RepositoryTest extends TestCase {
 
     public void testIPv6() {
         assertRepository(
-                "http://user:password@[fff:::1]:7891/oo/rest/users",
-                "http://[fff:::1]:7891/oo/rest/users",
+                "http://user:password@[fff::1]:7891/oo/rest/users",
+                "http://[fff::1]:7891/oo/rest/users",
                 "/oo/rest/users",
                 "user",
                 "password",
-                "fff:::1",
+                "fff::1",
                 7891);
         assertRepository(
-                "http://[fff:::1]:7891/oo/rest/users",
-                "http://[fff:::1]:7891/oo/rest/users",
+                "http://[fff::1]:7891/oo/rest/users",
+                "http://[fff::1]:7891/oo/rest/users",
                 "/oo/rest/users",
                 null,
                 null,
-                "fff:::1",
+                "fff::1",
                 7891);
         assertRepository(
-                "http://user:password@[fff:::1]/oo/rest/users",
-                "http://[fff:::1]/oo/rest/users",
+                "http://user:password@[fff::1]/oo/rest/users",
+                "http://[fff::1]/oo/rest/users",
                 "/oo/rest/users",
                 "user",
                 "password",
-                "fff:::1",
+                "fff::1",
                 -1);
         assertRepository(
-                "http://user:password@[fff:::1]:7891",
-                "http://[fff:::1]:7891",
+                "http://user:password@[fff::1]:7891",
+                "http://[fff::1]:7891",
                 "/",
                 "user",
                 "password",
-                "fff:::1",
+                "fff::1",
                 7891);
 
         assertRepository(

--- a/wagon-provider-api/src/test/java/org/apache/maven/wagon/repository/RepositoryTest.java
+++ b/wagon-provider-api/src/test/java/org/apache/maven/wagon/repository/RepositoryTest.java
@@ -120,13 +120,7 @@ public class RepositoryTest extends TestCase {
                 "fff::1",
                 -1);
         assertRepository(
-                "http://user:password@[fff::1]:7891",
-                "http://[fff::1]:7891",
-                "/",
-                "user",
-                "password",
-                "fff::1",
-                7891);
+                "http://user:password@[fff::1]:7891", "http://[fff::1]:7891", "/", "user", "password", "fff::1", 7891);
 
         assertRepository(
                 "http://user:password@[fff:000::222:1111]:7891/oo/rest/users",


### PR DESCRIPTION
This corrects the syntax of IPv6 URL used in tests so they use two colons instead of three. As is, they are syntactically incorrect IPv6 addresses. This would have been caught sooner if we had used java.net.URI instead of our hand rolled URI parsing code. (That's how I noticed this.) Fortunately our code does work with correct URLs with two colons instead of three. It shouldn't work with three colon URLs but it does. Fixing that by migrating to java.net.URI is up next. 