### PR TITLE
[WAGON-643] Deprecate dirname and filename methods in favor of java.nio.file.Path

### DIFF
--- a/wagon-provider-api/src/main/java/org/apache/maven/wagon/PathUtils.java
+++ b/wagon-provider-api/src/main/java/org/apache/maven/wagon/PathUtils.java
@@ -37,9 +37,9 @@ public final class PathUtils {
 
     /**
      * Returns the directory path portion of a file specification string.
-     * Matches the equally named unix command.
      *
-     * @return The directory portion excluding the ending file separator.
+     * @return the directory portion excluding the ending file separator
+     * @deprecated use {@code Paths.get(path).getParent().toString}
      */
     public static String dirname(final String path) {
         final int i = path.lastIndexOf("/");
@@ -50,13 +50,16 @@ public final class PathUtils {
     /**
      * Returns the filename portion of a file specification string.
      *
-     * @return The filename string with extension.
+     * @return the filename string with extension
+     * @deprecated use {@code Paths.get(path).getFileName().toString}
      */
+    @Deprecated
     public static String filename(final String path) {
         final int i = path.lastIndexOf("/");
         return ((i >= 0) ? path.substring(i + 1) : path);
     }
 
+    @Deprecated
     public static String[] dirnames(final String path) {
         final String dirname = PathUtils.dirname(path);
         return split(dirname, "/", -1);

--- a/wagon-provider-api/src/main/java/org/apache/maven/wagon/PathUtils.java
+++ b/wagon-provider-api/src/main/java/org/apache/maven/wagon/PathUtils.java
@@ -22,16 +22,17 @@ import java.io.File;
 import java.util.StringTokenizer;
 
 /**
- * Various path (URL) manipulation routines. Standard JDK methods in
- * java.net.URI and java.nio.file.Path should be used instead.
- * It's not always a direct one-to-one replacement. For instance,
- * a PathUtils method might return an empty string in a case where the
- * corresponding JDK method returns null. However, all logic in this
- * class has been present in the JDK since Java 1.4.
+ * Various path (URL) manipulation routines.
  *
  * @author <a href="michal.maczka@dimatics.com">Michal Maczka</a>
- *
+ * @deprecated Standard JDK methods in
+ *    java.net.URI and java.nio.file.Path should be used instead.
+ *    This is not always a direct one-to-one replacement. For instance,
+ *    a PathUtils method might return an empty string in a case where the
+ *    corresponding JDK method returns null. However, all logic in this
+ *    class has been present in the JDK since Java 1.4.
  */
+@Deprecated
 public final class PathUtils {
     private PathUtils() {}
 

--- a/wagon-provider-api/src/test/java/org/apache/maven/wagon/PathUtilsTest.java
+++ b/wagon-provider-api/src/test/java/org/apache/maven/wagon/PathUtilsTest.java
@@ -24,7 +24,6 @@ import junit.framework.TestCase;
 
 /**
  * @author <a href="michal.maczka@dimatics.com">Michal Maczka</a>
- *
  */
 public class PathUtilsTest extends TestCase {
     public void testFilenameResolving() {
@@ -43,7 +42,19 @@ public class PathUtilsTest extends TestCase {
         assertEquals("dir1/dir2", PathUtils.dirname("dir1/dir2/filename"));
     }
 
-    public void testDirSpliting() {
+    // A characterization test that demonstrates the existing behavior does not
+    // match the Unix dirname function when a trailing slash is present.
+    public void testDirnameDoesNotStripTrailingSlash() {
+        assertEquals("dir1/dir2/filename", PathUtils.dirname("dir1/dir2/filename/"));
+    }
+
+    // A characterization test that demonstrates the existing behavior does not
+    // match the Unix dirname function when a trailing slash is present.
+    public void testFilenameDoesNotStripTrailingSlash() {
+        assertEquals("", PathUtils.filename("dir1/dir2/filename/"));
+    }
+
+    public void testDirSplitting() {
         final String path = "a/b/c";
 
         final String[] dirs = PathUtils.dirnames(path);


### PR DESCRIPTION
Contrary to documentation, these methods do not behave the same as the Unix dirname command when a trailing slash is present. Arguably this is a bug. In this PR, I haven't changed this behavior, just added a couple of characterization tests that demonstrate the current behavior.