### PR TITLE
Replace plexus IO methods with JDK methods

### DIFF
--- a/wagon-provider-api/src/main/java/org/apache/maven/wagon/WagonUtils.java
+++ b/wagon-provider-api/src/main/java/org/apache/maven/wagon/WagonUtils.java
@@ -20,10 +20,10 @@ package org.apache.maven.wagon;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
 import java.util.LinkedList;
 
 import org.apache.maven.wagon.authorization.AuthorizationException;
-import org.codehaus.plexus.util.FileUtils;
 
 /**
  * @author <a href="mailto:mmaczka@interia.pl">Michal Maczka</a>
@@ -43,7 +43,9 @@ public final class WagonUtils {
 
             wagon.get(resource, file);
 
-            return FileUtils.fileRead(file);
+            byte[] content = Files.readAllBytes(file.toPath());
+            // TODO this method should take a character set
+            return new String(content);
         } finally {
             if (file != null) {
                 boolean deleted = file.delete();

--- a/wagon-provider-api/src/test/java/org/apache/maven/wagon/AbstractWagonTest.java
+++ b/wagon-provider-api/src/test/java/org/apache/maven/wagon/AbstractWagonTest.java
@@ -21,6 +21,8 @@ package org.apache.maven.wagon;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 
 import junit.framework.TestCase;
 import org.apache.maven.wagon.authentication.AuthenticationException;
@@ -35,7 +37,6 @@ import org.apache.maven.wagon.proxy.ProxyInfoProvider;
 import org.apache.maven.wagon.repository.Repository;
 import org.apache.maven.wagon.repository.RepositoryPermissions;
 import org.apache.maven.wagon.resource.Resource;
-import org.codehaus.plexus.util.FileUtils;
 import org.easymock.IAnswer;
 
 import static org.easymock.EasyMock.*;
@@ -434,7 +435,7 @@ public class AbstractWagonTest extends TestCase {
         File tempFile = File.createTempFile("wagon", "tmp");
         tempFile.deleteOnExit();
         String content = "content";
-        FileUtils.fileWrite(tempFile.getAbsolutePath(), content);
+        Files.write(tempFile.toPath().toAbsolutePath(), content.getBytes(StandardCharsets.UTF_8));
 
         Resource resource = new Resource("resource");
 

--- a/wagon-provider-api/src/test/java/org/apache/maven/wagon/LazyFileOutputStreamTest.java
+++ b/wagon-provider-api/src/test/java/org/apache/maven/wagon/LazyFileOutputStreamTest.java
@@ -19,9 +19,10 @@
 package org.apache.maven.wagon;
 
 import java.io.File;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 
 import junit.framework.TestCase;
-import org.codehaus.plexus.util.FileUtils;
 
 /**
  * @author <a href="mailto:mmaczka@interia.pl">Michal Maczka</a>
@@ -42,13 +43,13 @@ public class LazyFileOutputStreamTest extends TestCase {
 
         String expected = "michal";
 
-        stream.write(expected.getBytes());
+        stream.write(expected.getBytes(StandardCharsets.UTF_8));
 
         stream.close();
 
         assertTrue(file.exists());
 
-        String actual = FileUtils.fileRead(file);
+        String actual = new String(Files.readAllBytes(file.toPath()), StandardCharsets.UTF_8);
 
         assertEquals(expected, actual);
     }

--- a/wagon-provider-api/src/test/java/org/apache/maven/wagon/StreamWagonTest.java
+++ b/wagon-provider-api/src/test/java/org/apache/maven/wagon/StreamWagonTest.java
@@ -24,6 +24,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.text.SimpleDateFormat;
 
 import junit.framework.TestCase;
@@ -33,7 +34,6 @@ import org.apache.maven.wagon.events.TransferEvent;
 import org.apache.maven.wagon.events.TransferListener;
 import org.apache.maven.wagon.repository.Repository;
 import org.apache.maven.wagon.resource.Resource;
-import org.codehaus.plexus.util.FileUtils;
 
 import static org.easymock.EasyMock.*;
 
@@ -277,7 +277,8 @@ public class StreamWagonTest extends TestCase {
         wagon.connect(repository);
         try {
             wagon.get("resource", tempFile);
-            assertEquals(content, FileUtils.fileRead(tempFile));
+            String actual = new String(Files.readAllBytes(tempFile.toPath()));
+            assertEquals(content, actual);
         } finally {
             wagon.disconnect();
             tempFile.delete();
@@ -375,7 +376,7 @@ public class StreamWagonTest extends TestCase {
         final String content = "the content to return";
 
         final File tempFile = File.createTempFile("wagon", "tmp");
-        FileUtils.fileWrite(tempFile.getAbsolutePath(), content);
+        Files.write(tempFile.toPath().toAbsolutePath(), content.getBytes());
         tempFile.deleteOnExit();
 
         OutputStream out = new ByteArrayOutputStream();

--- a/wagon-provider-test/src/main/java/org/apache/maven/wagon/WagonTestCase.java
+++ b/wagon-provider-test/src/main/java/org/apache/maven/wagon/WagonTestCase.java
@@ -21,6 +21,7 @@ package org.apache.maven.wagon;
 import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.security.NoSuchAlgorithmException;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
@@ -54,6 +55,7 @@ import static org.easymock.EasyMock.getCurrentArguments;
 import static org.easymock.EasyMock.replay;
 import static org.easymock.EasyMock.reset;
 import static org.easymock.EasyMock.verify;
+import static org.junit.Assert.assertArrayEquals;
 
 /**
  * @author <a href="mailto:jason@maven.org">Jason van Zyl</a>
@@ -325,9 +327,9 @@ public abstract class WagonTestCase extends PlexusTestCase {
             // the repository with the contents of the artifact that was
             // retrieved from the repository.
 
-            String sourceContent = FileUtils.fileRead(sourceFile);
-            String destContent = FileUtils.fileRead(destFile);
-            assertEquals(sourceContent, destContent);
+            byte[] sourceContent = Files.readAllBytes(sourceFile.toPath());
+            byte[] destContent = Files.readAllBytes(destFile.toPath());
+            assertArrayEquals(sourceContent, destContent);
         } else {
             verify(mockTransferListener);
 
@@ -583,7 +585,7 @@ public abstract class WagonTestCase extends PlexusTestCase {
     private void writeTestFile(String child) throws IOException {
         File dir = new File(sourceFile, child);
         dir.getParentFile().mkdirs();
-        FileUtils.fileWrite(dir.getAbsolutePath(), child);
+        Files.write(dir.toPath().toAbsolutePath(), child.getBytes());
     }
 
     public void testFailedGet() throws Exception {
@@ -788,7 +790,7 @@ public abstract class WagonTestCase extends PlexusTestCase {
     protected void putFile(String resourceName, String testFileName, String content) throws Exception {
         sourceFile = new File(FileTestUtils.getTestOutputDir(), testFileName);
         sourceFile.getParentFile().mkdirs();
-        FileUtils.fileWrite(sourceFile.getAbsolutePath(), content);
+        Files.write(sourceFile.toPath().toAbsolutePath(), content.getBytes());
 
         Wagon wagon = getWagon();
 
@@ -958,15 +960,13 @@ public abstract class WagonTestCase extends PlexusTestCase {
 
         assertEquals("compare checksums", TEST_CKSUM, checksumObserver.getActualChecksum());
 
-        // Now compare the conents of the artifact that was placed in
+        // Now compare the contents of the artifact that was placed in
         // the repository with the contents of the artifact that was
         // retrieved from the repository.
 
-        String sourceContent = FileUtils.fileRead(sourceFile);
-
-        String destContent = FileUtils.fileRead(destFile);
-
-        assertEquals(sourceContent, destContent);
+        byte[] sourceContent = Files.readAllBytes(sourceFile.toPath());
+        byte[] destContent = Files.readAllBytes(destFile.toPath());
+        assertArrayEquals(sourceContent, destContent);
     }
 
     // ----------------------------------------------------------------------

--- a/wagon-providers/wagon-ssh-common-test/src/main/java/org/apache/maven/wagon/providers/ssh/ShellCommand.java
+++ b/wagon-providers/wagon-ssh-common-test/src/main/java/org/apache/maven/wagon/providers/ssh/ShellCommand.java
@@ -22,11 +22,11 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.nio.file.Files;
 
 import org.apache.sshd.server.Command;
 import org.apache.sshd.server.Environment;
 import org.apache.sshd.server.ExitCallback;
-import org.codehaus.plexus.util.FileUtils;
 import org.codehaus.plexus.util.cli.CommandLineUtils;
 import org.codehaus.plexus.util.cli.Commandline;
 
@@ -80,9 +80,9 @@ public class ShellCommand implements Command {
         CommandLineUtils.StringStreamConsumer stdout = new CommandLineUtils.StringStreamConsumer();
         try {
 
-            // hackhish defaut commandline tools not support ; or && so write a file with the script
+            // hackish default commandline tools not support ; or && so write a file with the script
             // and "/bin/sh -e " + tmpFile.getPath();
-            FileUtils.fileWrite(tmpFile, commandLine);
+            Files.write(tmpFile.toPath(), commandLine.getBytes());
 
             Commandline cl = new Commandline();
             cl.setExecutable("/bin/sh");

--- a/wagon-providers/wagon-ssh-common-test/src/main/java/org/apache/maven/wagon/providers/ssh/TestData.java
+++ b/wagon-providers/wagon-ssh-common-test/src/main/java/org/apache/maven/wagon/providers/ssh/TestData.java
@@ -20,8 +20,8 @@ package org.apache.maven.wagon.providers.ssh;
 
 import java.io.File;
 import java.io.IOException;
-
-import org.codehaus.plexus.util.FileUtils;
+import java.nio.file.Files;
+import java.nio.file.Path;
 
 /**
  * @author <a href="michal@codehaus.org">Michal Maczka</a>
@@ -62,7 +62,8 @@ public class TestData {
 
     public static String getHostKey() {
         try {
-            return FileUtils.fileRead(new File(System.getProperty("sshKeysPath"), "id_rsa.pub").getPath())
+            Path sshKeysPath = new File(System.getProperty("sshKeysPath"), "id_rsa.pub").toPath();
+            return new String(Files.readAllBytes(sshKeysPath))
                     .substring("ssh-rsa".length())
                     .trim();
         } catch (IOException e) {

--- a/wagon-providers/wagon-ssh-common/src/test/java/org/apache/maven/wagon/providers/ssh/knownhost/FileKnownHostsProviderTest.java
+++ b/wagon-providers/wagon-ssh-common/src/test/java/org/apache/maven/wagon/providers/ssh/knownhost/FileKnownHostsProviderTest.java
@@ -19,9 +19,13 @@
 package org.apache.maven.wagon.providers.ssh.knownhost;
 
 import java.io.File;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 
 import junit.framework.TestCase;
 import org.codehaus.plexus.util.FileUtils;
+
+import static org.junit.Assert.assertNotEquals;
 
 public class FileKnownHostsProviderTest extends TestCase {
     private File basedir = new File(System.getProperty("basedir", "."));
@@ -44,7 +48,7 @@ public class FileKnownHostsProviderTest extends TestCase {
         long timestamp = this.testKnownHostsFile.lastModified();
         // file with the same contents, but with entries swapped
         File sameKnownHostFile = new File(basedir, "src/test/resources/known_hosts_same");
-        String contents = FileUtils.fileRead(sameKnownHostFile);
+        String contents = new String(Files.readAllBytes(sameKnownHostFile.toPath()), StandardCharsets.US_ASCII);
 
         provider.storeKnownHosts(contents);
         assertEquals("known_hosts file is rewritten", timestamp, testKnownHostsFile.lastModified());
@@ -53,10 +57,10 @@ public class FileKnownHostsProviderTest extends TestCase {
     public void testStoreKnownHostsWithChange() throws Exception {
         long timestamp = this.testKnownHostsFile.lastModified();
         File sameKnownHostFile = new File(basedir, "src/test/resources/known_hosts_same");
-        String contents = FileUtils.fileRead(sameKnownHostFile);
+        String contents = new String(Files.readAllBytes(sameKnownHostFile.toPath()), StandardCharsets.US_ASCII);
         contents += "1 2 3";
 
         provider.storeKnownHosts(contents);
-        assertTrue("known_hosts file is not rewritten", timestamp != testKnownHostsFile.lastModified());
+        assertNotEquals("known_hosts file is not rewritten", timestamp, testKnownHostsFile.lastModified());
     }
 }

--- a/wagon-tcks/wagon-tck-http/src/main/java/org/apache/maven/wagon/tck/http/Assertions.java
+++ b/wagon-tcks/wagon-tck-http/src/main/java/org/apache/maven/wagon/tck/http/Assertions.java
@@ -23,6 +23,7 @@ import javax.servlet.http.HttpServletResponse;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.file.Files;
 
 import org.apache.maven.wagon.ResourceDoesNotExistException;
 import org.apache.maven.wagon.TransferFailedException;
@@ -33,14 +34,10 @@ import org.codehaus.plexus.util.IOUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static org.codehaus.plexus.util.FileUtils.fileRead;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
-/**
- *
- */
 public final class Assertions {
 
     public static final int NO_RESPONSE_STATUS_CODE = -1;
@@ -51,7 +48,7 @@ public final class Assertions {
             final String resourceBase, final String resourceName, final File output, final String whyWouldItFail)
             throws IOException {
         String content = readResource(resourceBase, resourceName);
-        String test = fileRead(output);
+        String test = new String(Files.readAllBytes(output.toPath()));
 
         assertEquals(whyWouldItFail, content, test);
     }

--- a/wagon-tcks/wagon-tck-http/src/main/java/org/apache/maven/wagon/tck/http/HttpWagonTests.java
+++ b/wagon-tcks/wagon-tck-http/src/main/java/org/apache/maven/wagon/tck/http/HttpWagonTests.java
@@ -34,6 +34,7 @@ import org.codehaus.plexus.DefaultPlexusContainer;
 import org.codehaus.plexus.PlexusContainer;
 import org.codehaus.plexus.component.configurator.ComponentConfigurationException;
 import org.codehaus.plexus.component.repository.exception.ComponentLifecycleException;
+import org.codehaus.plexus.util.FileUtils;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Before;
@@ -43,6 +44,9 @@ import org.slf4j.LoggerFactory;
 
 import static org.apache.maven.wagon.tck.http.util.TestUtil.getResource;
 
+/**
+ *
+ */
 public abstract class HttpWagonTests {
 
     private ServerFixture serverFixture;
@@ -54,6 +58,8 @@ public abstract class HttpWagonTests {
     private static WagonTestCaseConfigurator configurator;
 
     private String baseUrl;
+
+    private static final Set<File> TMP_FILES = new HashSet<>();
 
     private Repository repo;
 
@@ -117,6 +123,16 @@ public abstract class HttpWagonTests {
 
     @AfterClass
     public static void afterAll() {
+        for (File f : TMP_FILES) {
+            if (f.exists()) {
+                try {
+                    FileUtils.forceDelete(f);
+                } catch (IOException e) {
+                    e.printStackTrace();
+                }
+            }
+        }
+
         if (container != null) {
             try {
                 container.release(configurator);
@@ -246,6 +262,10 @@ public abstract class HttpWagonTests {
 
     protected static WagonTestCaseConfigurator getConfigurator() {
         return configurator;
+    }
+
+    protected static Set<File> getTmpfiles() {
+        return TMP_FILES;
     }
 
     protected Repository getRepo() {

--- a/wagon-tcks/wagon-tck-http/src/main/java/org/apache/maven/wagon/tck/http/HttpWagonTests.java
+++ b/wagon-tcks/wagon-tck-http/src/main/java/org/apache/maven/wagon/tck/http/HttpWagonTests.java
@@ -34,7 +34,6 @@ import org.codehaus.plexus.DefaultPlexusContainer;
 import org.codehaus.plexus.PlexusContainer;
 import org.codehaus.plexus.component.configurator.ComponentConfigurationException;
 import org.codehaus.plexus.component.repository.exception.ComponentLifecycleException;
-import org.codehaus.plexus.util.FileUtils;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Before;
@@ -44,9 +43,6 @@ import org.slf4j.LoggerFactory;
 
 import static org.apache.maven.wagon.tck.http.util.TestUtil.getResource;
 
-/**
- *
- */
 public abstract class HttpWagonTests {
 
     private ServerFixture serverFixture;
@@ -58,8 +54,6 @@ public abstract class HttpWagonTests {
     private static WagonTestCaseConfigurator configurator;
 
     private String baseUrl;
-
-    private static final Set<File> TMP_FILES = new HashSet<>();
 
     private Repository repo;
 
@@ -123,16 +117,6 @@ public abstract class HttpWagonTests {
 
     @AfterClass
     public static void afterAll() {
-        for (File f : TMP_FILES) {
-            if (f.exists()) {
-                try {
-                    FileUtils.forceDelete(f);
-                } catch (IOException e) {
-                    e.printStackTrace();
-                }
-            }
-        }
-
         if (container != null) {
             try {
                 container.release(configurator);
@@ -262,10 +246,6 @@ public abstract class HttpWagonTests {
 
     protected static WagonTestCaseConfigurator getConfigurator() {
         return configurator;
-    }
-
-    protected static Set<File> getTmpfiles() {
-        return TMP_FILES;
     }
 
     protected Repository getRepo() {


### PR DESCRIPTION
This reproduces existing dependencies on the default character set which is not always correct. That's going to require another PR.