### PR TITLE
Add Apache 2.0 LICENSE file

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,1 @@
+404: Not Found


### PR DESCRIPTION
This PR adds the standard Apache 2.0 LICENSE file from [maven-build-cache-extension](https://github.com/apache/maven-build-cache-extension).