### PR TITLE
wagon-ssh-external: Use absolute-dir in case `localFile.getParentFile` returns null

### DIFF
--- a/wagon-providers/wagon-ssh-external/src/main/java/org/apache/maven/wagon/providers/ssh/external/ScpExternalWagon.java
+++ b/wagon-providers/wagon-ssh-external/src/main/java/org/apache/maven/wagon/providers/ssh/external/ScpExternalWagon.java
@@ -229,7 +229,18 @@ public class ScpExternalWagon extends AbstractWagon implements CommandExecutor {
         }
         Commandline cl = createBaseCommandLine(putty, scpExecutable, privateKey);
 
-        cl.setWorkingDirectory(localFile.getParentFile().getAbsolutePath());
+        File parentFile = localFile.getParentFile();
+        if (null == parentFile) {
+            try {
+                File abs = localFile.getAbsoluteFile();
+                parentFile = abs.getParentFile();
+            } catch (SecurityException e) {
+                fireTransferError(resource, e, put ? TransferEvent.REQUEST_PUT : TransferEvent.REQUEST_GET);
+
+                throw new TransferFailedException("Error accessing absolute path of " + localFile, e);
+            }
+        }
+        cl.setWorkingDirectory(parentFile.getAbsolutePath());
 
         int port =
                 repository.getPort() == WagonConstants.UNKNOWN_PORT ? ScpHelper.DEFAULT_SSH_PORT : repository.getPort();


### PR DESCRIPTION
If using `mvn gpg:sign-and-deploy-file` as shown below, localFile becomes e.g. `gluegen-2.6.0-sources.jar`, i.e. relative and w/o parent-directory. Hence localFile.getParentFile() returns null and the previous code fails to transport the file.

```
mvn -e gpg:sign-and-deploy-file  \
  -DpomFile=pom.xml"             \
  -Dfile=gluegen.jar"            \
  -Dfiles=gluegen-2.6.0-sources.jar,gluegen-2.6.0-javadoc.jar" \
  -Dclassifiers=sources,javadoc" \
  -Dtypes=jar,jar"               \
  -Durl=scpexe://jordan/srv/www/jordan/deployment/maven/ \
  -DrepositoryId=jordan-mirror
```

This patch uses the localFile.getAbsoluteFile() in case localFile.getParentFile() returns null and renders wagon-ssh-external functional w/ above `mvn gpg:sign-and-deploy-file`

Tested via `mvn install -Dmaven.test.skip` and `mvn install` and JogAmp's maven install scripts at <https://jogamp.org/cgit/jogamp-scripting.git/>.

Following this checklist to help us incorporate your
contribution quickly and easily:

- [X] Your pull request should address just one issue, without pulling in other changes.
- [X] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [X] Each commit in the pull request should have a meaningful subject line and body.
  Note that commits might be squashed by a maintainer on merge.
- [ ] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied.
  This may not always be possible but is a best-practice.
- [X] Run `mvn verify` to make sure basic checks pass.
  A more thorough check will be performed on your pull request automatically.
- [ ] You have run the integration tests successfully (`mvn -Prun-its verify`).

If your pull request is about ~20 lines of code you don't need to sign an
[Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf) if you are unsure
please ask on the developers list.

To make clear that you license your contribution under
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

- [X] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
- [ ] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).
