### PR TITLE
[WAGON-583] WebDavWagon and tests now adhere to RFC 4918

### DIFF
--- a/wagon-providers/wagon-webdav-jackrabbit/src/main/java/org/apache/maven/wagon/providers/webdav/WebDavWagon.java
+++ b/wagon-providers/wagon-webdav-jackrabbit/src/main/java/org/apache/maven/wagon/providers/webdav/WebDavWagon.java
@@ -132,6 +132,9 @@ public class WebDavWagon extends AbstractHttpClientWagon {
             if (status == HttpStatus.SC_CONFLICT) {
                 continue;
             }
+            // Any other status is unexpected here: stop traversal and report an error
+            throw new IOException("Unexpected status code while creating collection: " + url
+                    + "; status code = " + status);
         } while (navigator.backward());
 
         // traverse forward creating missing directories
@@ -156,8 +159,8 @@ public class WebDavWagon extends AbstractHttpClientWagon {
                 org.apache.http.Header locationHeader = closeableHttpResponse.getFirstHeader("Location");
                 if (locationHeader != null) {
                     String redirectUrl = locationHeader.getValue();
-                    // Recursive call to handle redirect - execute() will handle the redirect automatically
-                    // but we need to return the final status
+                    // Follow the redirect by recursively invoking doMkCol on the new URL
+                    // and return the status code from the final resolved location
                     return doMkCol(redirectUrl);
                 }
             }
@@ -195,25 +198,10 @@ public class WebDavWagon extends AbstractHttpClientWagon {
     }
 
     protected boolean collectionExists(String url) throws IOException {
-        DavPropertyNameSet nameSet = new DavPropertyNameSet();
-        nameSet.add(DavPropertyName.create(DavConstants.PROPERTY_RESOURCETYPE));
-
-        CloseableHttpResponse closeableHttpResponse = null;
-        HttpPropfind method = null;
         try {
-            method = new HttpPropfind(url, nameSet, DavConstants.DEPTH_0);
-            closeableHttpResponse = execute(method);
-            int statusCode = closeableHttpResponse.getStatusLine().getStatusCode();
-            return statusCode == HttpStatus.SC_OK || statusCode == HttpStatus.SC_MULTI_STATUS;
-        } catch (HttpException e) {
+            return isDirectory(url);
+        } catch (DavException e) {
             throw new IOException(e.getMessage(), e);
-        } finally {
-            if (method != null) {
-                method.releaseConnection();
-            }
-            if (closeableHttpResponse != null) {
-                closeableHttpResponse.close();
-            }
         }
     }
 

--- a/wagon-providers/wagon-webdav-jackrabbit/src/test/java/org/apache/maven/wagon/providers/webdav/WebDavWagonTest.java
+++ b/wagon-providers/wagon-webdav-jackrabbit/src/test/java/org/apache/maven/wagon/providers/webdav/WebDavWagonTest.java
@@ -137,34 +137,35 @@ public class WebDavWagonTest extends HttpWagonTestCase {
         wagon.connect(testRepository, getAuthInfo());
 
         try {
-            File dir = getRepositoryDirectory();
-
-            // check basedir also doesn't exist and will need to be created
-            dir = new File(dir, testRepository.getBasedir());
-            assertFalse(dir.exists());
+            String repositoryUrl = testRepository.getUrl();
 
             // test leading /
-            assertFalse(new File(dir, "foo").exists());
+            String fooUrl = repositoryUrl + (repositoryUrl.endsWith("/") ? "" : "/") + "foo";
+            assertFalse("Collection should not exist before creation", wagon.collectionExists(fooUrl));
             wagon.mkdirs("/foo");
-            assertTrue(new File(dir, "foo").exists());
+            assertTrue("Collection should exist after creation", wagon.collectionExists(fooUrl));
 
             // test trailing /
-            assertFalse(new File(dir, "bar").exists());
+            String barUrl = repositoryUrl + (repositoryUrl.endsWith("/") ? "" : "/") + "bar";
+            assertFalse("Collection should not exist before creation", wagon.collectionExists(barUrl));
             wagon.mkdirs("bar/");
-            assertTrue(new File(dir, "bar").exists());
+            assertTrue("Collection should exist after creation", wagon.collectionExists(barUrl));
 
-            // test when already exists
+            // test when already exists (should not fail)
             wagon.mkdirs("bar");
+            assertTrue("Collection should still exist", wagon.collectionExists(barUrl));
 
             // test several parts
-            assertFalse(new File(dir, "1/2/3/4").exists());
+            String deepUrl = repositoryUrl + (repositoryUrl.endsWith("/") ? "" : "/") + "1/2/3/4";
+            assertFalse("Deep collection should not exist before creation", wagon.collectionExists(deepUrl));
             wagon.mkdirs("1/2/3/4");
-            assertTrue(new File(dir, "1/2/3/4").exists());
+            assertTrue("Deep collection should exist after creation", wagon.collectionExists(deepUrl));
 
             // test additional part and trailing /
-            assertFalse(new File(dir, "1/2/3/4/5").exists());
+            String deeperUrl = repositoryUrl + (repositoryUrl.endsWith("/") ? "" : "/") + "1/2/3/4/5";
+            assertFalse("Deeper collection should not exist before creation", wagon.collectionExists(deeperUrl));
             wagon.mkdirs("1/2/3/4/5/");
-            assertTrue(new File(dir, "1/2/3/4").exists());
+            assertTrue("Deeper collection should exist after creation", wagon.collectionExists(deeperUrl));
         } finally {
             wagon.disconnect();
 
@@ -186,16 +187,13 @@ public class WebDavWagonTest extends HttpWagonTestCase {
         wagon.connect(testRepository, getAuthInfo());
 
         try {
-            File dir = getRepositoryDirectory();
-
-            // check basedir also doesn't exist and will need to be created
-            dir = new File(dir, testRepository.getBasedir());
-            assertTrue(dir.exists());
+            String repositoryUrl = testRepository.getUrl();
 
             // test leading /
-            assertFalse(new File(dir, "foo").exists());
+            String fooUrl = repositoryUrl + (repositoryUrl.endsWith("/") ? "" : "/") + "foo";
+            assertFalse("Collection should not exist before creation", wagon.collectionExists(fooUrl));
             wagon.mkdirs("/foo");
-            assertTrue(new File(dir, "foo").exists());
+            assertTrue("Collection should exist after creation", wagon.collectionExists(fooUrl));
         } finally {
             wagon.disconnect();
 


### PR DESCRIPTION
- Handle 409 Conflict status when parent collections don't exist
- Handle redirects on MKCOL operations
- Accept 200 OK status for already-existing collections
- Fix tests to use WebDAV PROPFIND instead of filesystem checks