### PR TITLE
Restore the document metadata dropped when the pages were ported

### DIFF
--- a/src/site/markdown/privacy-policy.md
+++ b/src/site/markdown/privacy-policy.md
@@ -1,3 +1,10 @@
+---
+title: Privacy Policy
+author: 
+  - Olivier Lamy
+date: 2012-06-18
+---
+
 <!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file

--- a/wagon-provider-api/src/site/markdown/index.md
+++ b/wagon-provider-api/src/site/markdown/index.md
@@ -1,3 +1,10 @@
+---
+title: Maven Wagon API
+author: 
+  - Carlos Sanchez
+date: 2006-04-16
+---
+
 <!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file

--- a/wagon-provider-test/src/site/markdown/index.md
+++ b/wagon-provider-test/src/site/markdown/index.md
@@ -1,3 +1,10 @@
+---
+title: Maven Wagon Test
+author: 
+  - Carlos Sanchez
+date: 2006-04-16
+---
+
 <!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file

--- a/wagon-providers/wagon-file/src/site/markdown/index.md
+++ b/wagon-providers/wagon-file/src/site/markdown/index.md
@@ -1,3 +1,10 @@
+---
+title: Maven Wagon File
+author: 
+  - Carlos Sanchez
+date: 2006-04-16
+---
+
 <!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file

--- a/wagon-providers/wagon-ftp/src/site/markdown/index.md
+++ b/wagon-providers/wagon-ftp/src/site/markdown/index.md
@@ -1,3 +1,10 @@
+---
+title: Maven Wagon FTP
+author: 
+  - Carlos Sanchez
+date: 2006-06-04
+---
+
 <!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file

--- a/wagon-providers/wagon-http-lightweight/src/site/markdown/index.md
+++ b/wagon-providers/wagon-http-lightweight/src/site/markdown/index.md
@@ -1,3 +1,10 @@
+---
+title: Maven Wagon HTTP lightweight
+author: 
+  - Carlos Sanchez
+date: 2011-09-20
+---
+
 <!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file

--- a/wagon-providers/wagon-http/src/site/markdown/index.md
+++ b/wagon-providers/wagon-http/src/site/markdown/index.md
@@ -1,3 +1,11 @@
+---
+title: Maven Wagon HTTP
+author: 
+  - Carlos Sanchez
+  - Olivier Lamy
+date: 2013-02-05
+---
+
 <!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file

--- a/wagon-providers/wagon-scm/src/site/markdown/index.md
+++ b/wagon-providers/wagon-scm/src/site/markdown/index.md
@@ -1,3 +1,10 @@
+---
+title: Introduction
+author: 
+  - Carlos Sanchez
+date: 2006-03-07
+---
+
 <!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file

--- a/wagon-providers/wagon-scm/src/site/markdown/usage.md.vm
+++ b/wagon-providers/wagon-scm/src/site/markdown/usage.md.vm
@@ -1,3 +1,10 @@
+---
+title: Maven Wagon SCM
+author: 
+  - Carlos Sanchez
+date: 2011-09-22
+---
+
 <!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file

--- a/wagon-providers/wagon-ssh-external/src/site/markdown/index.md
+++ b/wagon-providers/wagon-ssh-external/src/site/markdown/index.md
@@ -1,3 +1,10 @@
+---
+title: Maven Wagon SSH External
+author: 
+  - Carlos Sanchez
+date: 2006-04-16
+---
+
 <!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file

--- a/wagon-providers/wagon-ssh/src/site/markdown/index.md
+++ b/wagon-providers/wagon-ssh/src/site/markdown/index.md
@@ -1,3 +1,10 @@
+---
+title: Maven Wagon SSH
+author: 
+  - Carlos Sanchez
+date: 2006-06-04
+---
+
 <!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file

--- a/wagon-providers/wagon-webdav-jackrabbit/src/site/markdown/index.md
+++ b/wagon-providers/wagon-webdav-jackrabbit/src/site/markdown/index.md
@@ -1,3 +1,10 @@
+---
+title: Maven Wagon WebDAV
+author: 
+  - Carlos Sanchez
+date: 2012-11-19
+---
+
 <!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file


### PR DESCRIPTION
The site pages lost their document metadata when they were ported from APT.

An APT document opens with a header block giving its title, authors and date, and
`doxia-converter` turns that into YAML front matter. The port dropped the front matter
along with the converter's per-line licence comments, so the generated pages lost their
`<meta name="author">` and date, and took their `<title>` from the first heading instead
of from the document title.

Building one project's site from the APT sources and from the ported Markdown shows the
difference:

| | `<title>` produced |
|---|---|
| APT original | `Release Notes - Modello` |
| ported Markdown | `Modello - Modello` |
| with this change | `Release Notes - Modello` |

The front matter has to come first in the file, because the Markdown parser only looks
for it when the source begins with `---`; a licence header ahead of it would hide it.
RAT is happy either way.

Verified by building the site before and after and comparing `<title>` and the author
meta tags of every generated page, and by confirming the front matter does not reach
the rendered body.