### PR TITLE
Bump org.apache.jackrabbit:jackrabbit-webdav from 2.14.4 to 2.20.17

### DIFF
--- a/wagon-providers/wagon-webdav-jackrabbit/pom.xml
+++ b/wagon-providers/wagon-webdav-jackrabbit/pom.xml
@@ -51,15 +51,11 @@ under the License.
     <dependency>
       <groupId>org.apache.jackrabbit</groupId>
       <artifactId>jackrabbit-webdav</artifactId>
-      <version>2.14.4</version>
+      <version>2.20.17</version>
       <exclusions>
         <exclusion>
           <groupId>commons-logging</groupId>
           <artifactId>commons-logging</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>commons-httpclient</groupId>
-          <artifactId>commons-httpclient</artifactId>
         </exclusion>
       </exclusions>
     </dependency>


### PR DESCRIPTION
Bumps `jackrabbit-webdav` in `wagon-webdav-jackrabbit` from 2.14.4 (released 2018) to 2.20.17, and removes an exclusion that the bump makes obsolete.

### Why 2.20.17 and not 2.22.x

2.20.17 is the last release of the 2.20.x line, which is the newest Jackrabbit line still targeting Java 8. The switch to Java 11 landed in **2.21.23** — `jackrabbit-parent` goes from `<java.version>1.8</java.version>` (2.21.22) to `<javaTargetVersion>11</javaTargetVersion>` with `maven.compiler.release` (2.21.23), and the published jars follow:

| version | max class-file major | |
|---|---|---|
| 2.20.17 | 52 | Java 8 |
| 2.21.20 – 2.21.22 | 52 | Java 8 |
| 2.21.23 | 55 | Java 11 |
| 2.22.0 – 2.22.4 | 55 | Java 11 |

So 2.22.x is out until Wagon raises its own baseline. 2.21.22 is technically the highest Java 8 build, but 2.21.x is Jackrabbit's unstable line, so 2.20.17 is the right target.

### Dropping the commons-httpclient exclusion

2.14.4 still declared a dependency on the long-retired `commons-httpclient:3.1` (the HttpClient 3 API), which this module excluded. 2.20.x drops it entirely and depends only on `httpclient 4.5.14` / `httpcore 4.4.16`, so the exclusion is now dead configuration. The `commons-logging` exclusion is kept — that one still comes in via httpclient 4.5.14.

The resulting dependency tree gains no new artifacts beyond `commons-codec:1.11` under httpclient.

### Verification

- Full reactor builds clean.
- `wagon-webdav-jackrabbit` tests: 283 run, 0 failures, 0 errors, 0 skipped.
- Enforcer's `enforce-bytecode-version` rule passes, confirming 2.20.17 satisfies the Java 8 baseline.

Note: `mvn verify` currently fails the `drop-legacy-dependencies` enforcer rule on `plexus-container-default:2.1.1` coming from `wagon-provider-test`. I confirmed that failure is pre-existing on an unmodified `master` and unrelated to this change.

---

- [x] Your pull request should address just one issue, without pulling in other changes.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body.
- [x] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied. — N/A, dependency bump covered by the existing suite.
- [x] Run `mvn verify` to make sure basic checks pass.
- [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)