### PR TITLE
[wagon-3.x] Revive the embedded SSH tests and run them in CI

### DIFF
--- a/.github/workflows/maven-verify.yml
+++ b/.github/workflows/maven-verify.yml
@@ -28,3 +28,7 @@ jobs:
     with:
       install-subversion: true
       matrix-exclude: '[ {"jdk": "25"} ]'
+      # -Dssh-tests turns off the no-ssh-tests profiles, -Dssh-embedded=true then narrows the ssh providers down
+      # to the tests that run against the embedded Apache MINA sshd; the rest need a real sshd on localhost:22.
+      # Repeats the workflow's own default for maven-args, which this input replaces rather than extends.
+      maven-args: '-D"invoker.streamLogsOnFailures" -Dssh-tests -Dssh-embedded=true'

--- a/wagon-providers/wagon-ssh-common-test/src/main/java/org/apache/maven/wagon/providers/ssh/AbstractEmbeddedScpWagonTest.java
+++ b/wagon-providers/wagon-ssh-common-test/src/main/java/org/apache/maven/wagon/providers/ssh/AbstractEmbeddedScpWagonTest.java
@@ -78,7 +78,10 @@ public abstract class AbstractEmbeddedScpWagonTest extends StreamingWagonTestCas
     }
 
     protected long getExpectedLastModifiedOnGet(Repository repository, Resource resource) {
-        return new File(repository.getBasedir(), resource.getName()).lastModified();
+        // the scp protocol carries the modification time in whole seconds (the "T" header), so that is the
+        // precision the wagon reports back - truncate to match, the "remote" file here is a local file whose
+        // timestamp still has millisecond precision
+        return new File(repository.getBasedir(), resource.getName()).lastModified() / 1000L * 1000L;
     }
 
     @Override

--- a/wagon-providers/wagon-ssh-common-test/src/main/java/org/apache/maven/wagon/providers/ssh/AbstractEmbeddedScpWagonWithKeyTest.java
+++ b/wagon-providers/wagon-ssh-common-test/src/main/java/org/apache/maven/wagon/providers/ssh/AbstractEmbeddedScpWagonWithKeyTest.java
@@ -76,7 +76,10 @@ public abstract class AbstractEmbeddedScpWagonWithKeyTest extends StreamingWagon
     }
 
     protected long getExpectedLastModifiedOnGet(Repository repository, Resource resource) {
-        return new File(repository.getBasedir(), resource.getName()).lastModified();
+        // the scp protocol carries the modification time in whole seconds (the "T" header), so that is the
+        // precision the wagon reports back - truncate to match, the "remote" file here is a local file whose
+        // timestamp still has millisecond precision
+        return new File(repository.getBasedir(), resource.getName()).lastModified() / 1000L * 1000L;
     }
 
     public void testConnect() throws Exception {

--- a/wagon-providers/wagon-ssh-common-test/src/main/java/org/apache/maven/wagon/providers/ssh/ShellCommand.java
+++ b/wagon-providers/wagon-ssh-common-test/src/main/java/org/apache/maven/wagon/providers/ssh/ShellCommand.java
@@ -126,12 +126,6 @@ public class ShellCommand implements Command {
                 callback.onExit(exitValue, stdout.getOutput());
             }
         }
-        /*
-        out.write( exitValue );
-        out.write( '\n' );
-
-        */
-        out.flush();
     }
 
     public void destroy(ChannelSession channel) throws Exception {}

--- a/wagon-providers/wagon-ssh-common-test/src/main/java/org/apache/maven/wagon/providers/ssh/SshServerEmbedded.java
+++ b/wagon-providers/wagon-ssh-common-test/src/main/java/org/apache/maven/wagon/providers/ssh/SshServerEmbedded.java
@@ -21,6 +21,7 @@ package org.apache.maven.wagon.providers.ssh;
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 import org.apache.sshd.common.file.nativefs.NativeFileSystemFactory;
@@ -29,6 +30,7 @@ import org.apache.sshd.server.SshServer;
 import org.apache.sshd.server.auth.password.PasswordAuthenticator;
 import org.apache.sshd.server.keyprovider.SimpleGeneratorHostKeyProvider;
 import org.apache.sshd.server.shell.ProcessShellFactory;
+import org.apache.sshd.sftp.server.SftpSubsystemFactory;
 
 /**
  * @author Olivier Lamy
@@ -96,6 +98,10 @@ public class SshServerEmbedded {
                 .withDelegate((channel, command) -> new ShellCommand(command))
                 .build();
         sshd.setCommandFactory(commandFactory);
+
+        // OpenSSH 9 and later drive "scp" over the SFTP protocol rather than the legacy scp protocol, so the
+        // wagon-ssh-external tests, which shell out to the system scp, need the subsystem to be available
+        sshd.setSubsystemFactories(Collections.singletonList(new SftpSubsystemFactory()));
 
         sshd.setFileSystemFactory(new NativeFileSystemFactory());
         sshd.start();

--- a/wagon-providers/wagon-ssh-external/pom.xml
+++ b/wagon-providers/wagon-ssh-external/pom.xml
@@ -115,6 +115,12 @@ under the License.
               <excludes>
                 <exclude>**/SshCommandExecutorTest.*</exclude>
                 <exclude>**/Scp*Test.*</exclude>
+                <!-- This one does use the embedded server, but through the host's own ssh/scp binaries, and
+                     OpenSSH 9 and later drive scp over SFTP instead of the legacy scp protocol. The remote path
+                     is no longer expanded by a remote shell, so the backslash escaping ScpExternalWagon applies
+                     to paths with spaces reaches the server verbatim and the transfer fails. Until that is
+                     sorted out the result depends on the host's OpenSSH version, so it stays out of CI. -->
+                <exclude>**/EmbeddedScp*WagonWithKeyTest.*</exclude>
               </excludes>
             </configuration>
           </plugin>

--- a/wagon-providers/wagon-ssh/pom.xml
+++ b/wagon-providers/wagon-ssh/pom.xml
@@ -165,6 +165,12 @@ under the License.
     <profile>
       <id>ssh-embedded</id>
       <activation>
+        <!-- the embedded server runs the commands it receives through /bin/sh, so keep windauze in charge on
+             Windows: surefire <excludes> from two active profiles override rather than merge, and this profile
+             is declared last -->
+        <os>
+          <family>!windows</family>
+        </os>
         <property>
           <name>ssh-embedded</name>
           <value>true</value>
@@ -175,7 +181,7 @@ under the License.
           <plugin>
             <artifactId>maven-surefire-plugin</artifactId>
             <configuration>
-              <!-- Tests that currently doesn't work with embedded ssh server -->
+              <!-- Tests that need an ssh server on localhost:22 and the developer's own account there -->
               <excludes>
                 <exclude>**/SftpWagonTest.*</exclude>
                 <exclude>**/SshCommandExecutorTest.*</exclude>

--- a/wagon-providers/wagon-ssh/src/main/java/org/apache/maven/wagon/providers/ssh/jsch/ScpWagon.java
+++ b/wagon-providers/wagon-ssh/src/main/java/org/apache/maven/wagon/providers/ssh/jsch/ScpWagon.java
@@ -22,6 +22,7 @@ import java.io.EOFException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.util.Locale;
 
 import com.jcraft.jsch.ChannelExec;
 import com.jcraft.jsch.JSchException;
@@ -53,6 +54,12 @@ import org.apache.maven.wagon.resource.Resource;
  */
 public class ScpWagon extends AbstractJschWagon {
     private static final char COPY_START_CHAR = 'C';
+
+    /** scp acknowledgement byte for a recoverable error, what OpenSSH sends for a missing file */
+    private static final int SCP_WARNING = 1;
+
+    /** scp acknowledgement byte for a fatal error */
+    private static final int SCP_ERROR = 2;
 
     private static final char ACK_SEPARATOR = ' ';
 
@@ -222,9 +229,13 @@ public class ScpWagon extends AbstractJschWagon {
             String line = readLine(in);
 
             if (exitCode != COPY_START_CHAR) {
-                if (exitCode == 1
-                        && (line.contains("No such file or directory")
-                                || line.indexOf("no such file or directory") != 1)) {
+                // OpenSSH reports a missing file with the scp "warning" code (1); other servers - Apache MINA
+                // sshd, which the tests run against - report it with the "fatal error" code (2), so fall back on
+                // the message for those
+                if (exitCode == SCP_WARNING
+                        || (exitCode == SCP_ERROR
+                                && line != null
+                                && line.toLowerCase(Locale.ROOT).contains("no such file or directory"))) {
                     throw new ResourceDoesNotExistException(line);
                 } else {
                     throw new IOException("Exit code: " + exitCode + " - " + line);

--- a/wagon-providers/wagon-ssh/src/test/java/org/apache/maven/wagon/providers/ssh/jsch/TestPrompter.java
+++ b/wagon-providers/wagon-ssh/src/test/java/org/apache/maven/wagon/providers/ssh/jsch/TestPrompter.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.wagon.providers.ssh.jsch;
+
+import java.util.List;
+
+import org.codehaus.plexus.components.interactivity.Prompter;
+import org.codehaus.plexus.components.interactivity.PrompterException;
+
+/**
+ * A {@link Prompter} for the tests, wired in through
+ * {@code src/test/resources/META-INF/plexus/components.xml}.
+ * <p>
+ * {@code plexus-interactivity-api} stopped shipping a {@code META-INF/plexus/components.xml} in 1.3, so its
+ * {@code DefaultPrompter} is invisible to the {@code plexus-container-default} that {@code PlexusTestCase} runs;
+ * without a replacement every {@code lookup( Wagon.ROLE, "scp" )} fails because {@code ConsoleInteractiveUserInfo}
+ * and {@code PrompterUIKeyboardInteractive} both require one.
+ * <p>
+ * The tests are non-interactive, so nothing should ever prompt: every method throws rather than blocking on
+ * {@code System.in}.
+ */
+public class TestPrompter implements Prompter {
+
+    public String prompt(String message) throws PrompterException {
+        throw unexpected(message);
+    }
+
+    public String prompt(String message, String defaultReply) throws PrompterException {
+        throw unexpected(message);
+    }
+
+    public String prompt(String message, List<String> possibleValues) throws PrompterException {
+        throw unexpected(message);
+    }
+
+    public String prompt(String message, List<String> possibleValues, String defaultReply) throws PrompterException {
+        throw unexpected(message);
+    }
+
+    public String promptForPassword(String message) throws PrompterException {
+        throw unexpected(message);
+    }
+
+    public void showMessage(String message) throws PrompterException {
+        // tests run non-interactively, but a message costs nothing and helps when a test does go interactive
+        System.out.println(message);
+    }
+
+    private PrompterException unexpected(String message) {
+        return new PrompterException("The tests are non-interactive, unexpected prompt: " + message);
+    }
+}

--- a/wagon-providers/wagon-ssh/src/test/resources/META-INF/plexus/components.xml
+++ b/wagon-providers/wagon-ssh/src/test/resources/META-INF/plexus/components.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~   http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<!--
+  plexus-interactivity-api dropped its own META-INF/plexus/components.xml in 1.3 and only ships a sisu index, so
+  plexus-container-default cannot see DefaultPrompter (which in any case now takes its collaborators through a
+  constructor, which plexus-container-default cannot satisfy). Maven itself runs on sisu and is unaffected; only
+  the PlexusTestCase-based tests here need this descriptor.
+-->
+<component-set>
+  <components>
+    <component>
+      <role>org.codehaus.plexus.components.interactivity.Prompter</role>
+      <role-hint>default</role-hint>
+      <implementation>org.apache.maven.wagon.providers.ssh.jsch.TestPrompter</implementation>
+    </component>
+  </components>
+</component-set>


### PR DESCRIPTION
The embedded SSH tests have not run in over a decade. This gets the embedded half of them green and runs it in CI.

### Why the suite could not start

`PlexusTestCase` uses `plexus-container-default`, which reads `META-INF/plexus/components.xml`. `plexus-interactivity-api` stopped shipping that descriptor in 1.3 and now ships only a sisu index — I checked the jars: 1.1 has the plexus descriptor and no sisu index, 1.5.1 the reverse. Maven itself runs on sisu, so nothing is wrong in production; only `PlexusTestCase` is affected.

The `ComponentLookupException` on the `scp` role hint hid five levels of cause. The bottom is a missing `Prompter`, which `ConsoleInteractiveUserInfo` and `PrompterUIKeyboardInteractive` both require and `AbstractJschWagon` needs both of. All 94 errors had that same bottom cause. It arrived with the 1.1 → 1.3 bump in `42ee3769`.

Writing a descriptor for the real `DefaultPrompter` does not work: it takes its collaborators through a constructor into final fields, and the container's builder only does no-arg construction plus field injection. So the tests get their own `Prompter`, in test scope, which throws rather than blocking on stdin.

### It was three faults, not one

The Prompter alone took 94 errors to 87.

- `ShellCommand` flushed the output stream *after* `ExitCallback.onExit()` had closed the channel. The server logged `SshChannelClosedException`, the session went down, and the next command in it died. Removing that one stray `flush()` took the embedded tests from 19 errors to 6.
- `getExpectedLastModifiedOnGet` compared at millisecond precision while the scp `T` header carries whole seconds, so the mock transfer event never matched and the progress assertion saw 0 bytes. Truncated to seconds.
- The embedded server registered no SFTP subsystem, and OpenSSH 9+ drives `scp` over SFTP, so every shelled-out `scp` exited 255.

### One production change, called out for review

`ScpWagon.fillInputData` mapped only scp ack code 1 to `ResourceDoesNotExistException`; MINA sshd reports a missing file with code 2. Without this, four tests stay red.

While there: `line.indexOf("no such file or directory") != 1` is a typo for `!= -1`, which makes *every* code-1 error a `ResourceDoesNotExistException`. I deliberately preserved that behaviour rather than quietly tightening it, so only code 2 is genuinely new. Worth fixing separately, with its own thought about what it changes.

### Counts

| | before | after |
|---|---|---|
| `wagon-ssh`, `-Dssh-tests -Dssh-embedded=true` | 42 tests, 24 errors | **42 tests, 0 failures** |
| `wagon-ssh`, `-Dssh-tests` alone | 112 tests, 94 errors | 112 tests, 8 errors + 2 failures |
| full reactor with both switches | — | BUILD SUCCESS |
| affected modules, no switches | — | BUILD SUCCESS |

No test was disabled or deleted.

### Why bare `-Dssh-tests` still cannot be green

By design of those tests, not by breakage. `ScpWagonTest`, `SshCommandExecutorTest` and `KnownHostsProviderTest` expect a real sshd on localhost:22 and the developer's own account. `SftpWagonTest` and `ScpWagonWithSshPrivateKeySearchTest` connect to `scp://localhost:0/`, broken since `35ff4024` removed `getTestRepositoryPort()`. Only `Embedded*Test` uses the embedded server, which is exactly what the existing `ssh-embedded` profile selects — hence the two-property combination in CI.

### CI

```yaml
maven-args: '-D"invoker.streamLogsOnFailures" -Dssh-tests -Dssh-embedded=true'
```

Two pom changes make that safe, both checked empirically rather than assumed. Surefire `<excludes>` from two active profiles **override rather than merge**, last declared winning — verified by running `-Dssh-embedded=true` without `-Dssh-tests` and watching the Embedded tests run anyway. On Windows that would have let `ssh-embedded` beat `windauze` and run the `/bin/sh`-dependent tests, so `ssh-embedded` now also requires a non-Windows OS. And `wagon-ssh-external`'s own `ssh-embedded` profile would have run a test that is not green, so it is excluded there with a comment; that module runs no ssh tests today, so nothing is lost.

If you would rather not carry a switch at all, dropping `**/Embedded*Test.*` from `no-ssh-tests` gives identical coverage with no workflow change.

### Caveats

Only exercised on JDK 21; the CI matrix includes JDK 8, and these tests are new to CI on every version. `wagon-ssh-external`'s `EmbeddedScpExternalWagonWithKeyTest` still fails on path quoting — `ScpExternalWagon` backslash-escapes spaces for the legacy remote-shell protocol, which SFTP-mode scp passes through verbatim. That needs a decision about `-O` versus changed quoting, and the answer depends on the host's OpenSSH version, so it is left alone here.

### Why this matters beyond itself

This is the only harness that runs the SSH provider against a real server. It is the precursor to #902 and #903: with it in place, the JSch swap those PRs make is verified rather than asserted — and it immediately earned that, catching a `NoClassDefFoundError` that would have stopped `wagon-ssh` loading at all.
