### PR TITLE
Replace the Plexus container with the Sisu Plexus shim

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -161,7 +161,7 @@ under the License.
     <slf4jVersion>1.7.36</slf4jVersion>
     <maven.site.path>wagon-archives/wagon-LATEST</maven.site.path>
     <version.plexus-utils>3.6.0</version.plexus-utils>
-    <version.sisu-maven-plugin>0.9.0.M3</version.sisu-maven-plugin>
+    <guiceVersion>5.1.0</guiceVersion>
     <!-- because doxia parser doesn't like the real one -->
     <mavenSitePluginVersion>${version.maven-site-plugin}</mavenSitePluginVersion>
     <project.build.outputTimestamp>2022-12-18T21:06:44Z</project.build.outputTimestamp>
@@ -199,10 +199,17 @@ under the License.
         <artifactId>plexus-interactivity-api</artifactId>
         <version>1.5.1</version>
       </dependency>
+      <!--
+       | The Plexus shim: org.eclipse.sisu.plexus supplies PlexusContainer and PlexusTestCase,
+       | and understands both META-INF/plexus/components.xml and JSR-330 @Named beans.
+       | Its version is managed by maven-parent. Guice is "provided" in the sisu POM,
+       | so it has to be declared here explicitly.
+      -->
       <dependency>
-        <groupId>org.codehaus.plexus</groupId>
-        <artifactId>plexus-container-default</artifactId>
-        <version>2.1.1</version>
+        <groupId>com.google.inject</groupId>
+        <artifactId>guice</artifactId>
+        <version>${guiceVersion}</version>
+        <classifier>classes</classifier>
       </dependency>
       <!-- for slf4j -->
       <dependency>

--- a/wagon-provider-test/pom.xml
+++ b/wagon-provider-test/pom.xml
@@ -36,8 +36,14 @@ under the License.
       <artifactId>wagon-provider-api</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.codehaus.plexus</groupId>
-      <artifactId>plexus-container-default</artifactId>
+      <groupId>org.eclipse.sisu</groupId>
+      <artifactId>org.eclipse.sisu.plexus</artifactId>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.google.inject</groupId>
+      <artifactId>guice</artifactId>
+      <classifier>classes</classifier>
       <scope>compile</scope>
     </dependency>
     <dependency>

--- a/wagon-provider-test/src/main/java/org/apache/maven/wagon/WagonTestCase.java
+++ b/wagon-provider-test/src/main/java/org/apache/maven/wagon/WagonTestCase.java
@@ -170,10 +170,6 @@ public abstract class WagonTestCase extends PlexusTestCase {
         }
     }
 
-    protected void customizeContext() throws Exception {
-        getContainer().addContextValue("test.repository", localRepositoryPath);
-    }
-
     protected void setupWagonTestingFixtures() throws Exception {}
 
     protected void tearDownWagonTestingFixtures() throws Exception {}

--- a/wagon-providers/wagon-http-lightweight/src/test/resources/META-INF/plexus/components.xml
+++ b/wagon-providers/wagon-http-lightweight/src/test/resources/META-INF/plexus/components.xml
@@ -24,14 +24,7 @@ under the License.
       <implementation>org.apache.maven.wagon.tck.http.WagonTestCaseConfigurator</implementation>
       <configuration>
         <wagonHint>http</wagonHint>
-        <useCaseConfigs>
-          <highLatencyLowTimeout>
-            <unsupported/>
-          </highLatencyLowTimeout>
-          <inifiniteLatencyTimeout>
-            <unsupported/>
-          </inifiniteLatencyTimeout>
-        </useCaseConfigs>
+        <useCaseConfigsResource>META-INF/wagon-tck/http-use-cases.xml</useCaseConfigsResource>
       </configuration>
     </component>
   </components>

--- a/wagon-providers/wagon-http-lightweight/src/test/resources/META-INF/wagon-tck/http-use-cases.xml
+++ b/wagon-providers/wagon-http-lightweight/src/test/resources/META-INF/wagon-tck/http-use-cases.xml
@@ -1,0 +1,26 @@
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-->
+<useCaseConfigs>
+  <highLatencyLowTimeout>
+    <unsupported/>
+  </highLatencyLowTimeout>
+  <inifiniteLatencyTimeout>
+    <unsupported/>
+  </inifiniteLatencyTimeout>
+</useCaseConfigs>

--- a/wagon-providers/wagon-http/pom.xml
+++ b/wagon-providers/wagon-http/pom.xml
@@ -85,8 +85,14 @@ under the License.
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.codehaus.plexus</groupId>
-      <artifactId>plexus-container-default</artifactId>
+      <groupId>org.eclipse.sisu</groupId>
+      <artifactId>org.eclipse.sisu.plexus</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.google.inject</groupId>
+      <artifactId>guice</artifactId>
+      <classifier>classes</classifier>
       <scope>test</scope>
     </dependency>
 

--- a/wagon-providers/wagon-http/src/test/resources/META-INF/plexus/components.xml
+++ b/wagon-providers/wagon-http/src/test/resources/META-INF/plexus/components.xml
@@ -24,14 +24,7 @@ under the License.
       <implementation>org.apache.maven.wagon.tck.http.WagonTestCaseConfigurator</implementation>
       <configuration>
         <wagonHint>http</wagonHint>
-        <useCaseConfigs>
-          <highLatencyLowTimeout>
-            <unsupported/>
-          </highLatencyLowTimeout>
-          <inifiniteLatencyTimeout>
-            <unsupported/>
-          </inifiniteLatencyTimeout>
-        </useCaseConfigs>
+        <useCaseConfigsResource>META-INF/wagon-tck/http-use-cases.xml</useCaseConfigsResource>
       </configuration>
     </component>
   </components>

--- a/wagon-providers/wagon-http/src/test/resources/META-INF/wagon-tck/http-use-cases.xml
+++ b/wagon-providers/wagon-http/src/test/resources/META-INF/wagon-tck/http-use-cases.xml
@@ -1,0 +1,26 @@
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-->
+<useCaseConfigs>
+  <highLatencyLowTimeout>
+    <unsupported/>
+  </highLatencyLowTimeout>
+  <inifiniteLatencyTimeout>
+    <unsupported/>
+  </inifiniteLatencyTimeout>
+</useCaseConfigs>

--- a/wagon-providers/wagon-scm/pom.xml
+++ b/wagon-providers/wagon-scm/pom.xml
@@ -45,6 +45,16 @@ under the License.
       <artifactId>maven-scm-manager-plexus</artifactId>
       <version>${mavenScmVersion}</version>
       <scope>runtime</scope>
+      <exclusions>
+        <!--
+         | Drags in plexus-container-default 1.0-alpha-9, which collides with the Plexus shim
+         | (two copies of PlexusContainer/PlexusTestCase on the test classpath).
+        -->
+        <exclusion>
+          <groupId>org.codehaus.plexus</groupId>
+          <artifactId>plexus-container-default</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.codehaus.plexus</groupId>

--- a/wagon-providers/wagon-scm/src/test/java/org/apache/maven/wagon/providers/scm/AbstractScmWagonTest.java
+++ b/wagon-providers/wagon-scm/src/test/java/org/apache/maven/wagon/providers/scm/AbstractScmWagonTest.java
@@ -20,8 +20,12 @@ package org.apache.maven.wagon.providers.scm;
 
 import java.io.File;
 import java.io.IOException;
+import java.lang.reflect.Field;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
+import org.apache.maven.scm.manager.AbstractScmManager;
 import org.apache.maven.scm.manager.plexus.DefaultScmManager;
 import org.apache.maven.scm.provider.ScmProvider;
 import org.apache.maven.wagon.FileTestUtils;
@@ -67,6 +71,8 @@ public abstract class AbstractScmWagonTest extends WagonTestCase {
             DefaultScmManager scmManager = (DefaultScmManager) wagon.getScmManager();
 
             if (getScmProvider() != null) {
+                makeScmProvidersMutable(scmManager);
+
                 scmManager.setScmProvider(getScmId(), getScmProvider());
 
                 providerClassName = getScmProvider().getClass().getName();
@@ -77,6 +83,25 @@ public abstract class AbstractScmWagonTest extends WagonTestCase {
 
             wagon.setCheckoutDirectory(getCheckoutDirectory());
         }
+    }
+
+    /**
+     * The container injects AbstractScmManager's provider map as an immutable map, so
+     * {@link org.apache.maven.scm.manager.AbstractScmManager#setScmProvider} cannot register a provider on it.
+     * The map is private with only a protected setter, so swap in a mutable copy reflectively.
+     */
+    private static void makeScmProvidersMutable(DefaultScmManager scmManager) throws Exception {
+        // DefaultScmManager declares a scmProviders field of its own for the injected providers, so target
+        // the one AbstractScmManager.setScmProvider actually writes to rather than walking up from the
+        // runtime class.
+        Field field = AbstractScmManager.class.getDeclaredField("scmProviders");
+
+        field.setAccessible(true);
+
+        @SuppressWarnings("unchecked")
+        Map<String, ScmProvider> providers = (Map<String, ScmProvider>) field.get(scmManager);
+
+        field.set(scmManager, providers == null ? new HashMap<>() : new HashMap<>(providers));
     }
 
     /**

--- a/wagon-providers/wagon-ssh-common-test/pom.xml
+++ b/wagon-providers/wagon-ssh-common-test/pom.xml
@@ -34,8 +34,14 @@ under the License.
   </properties>
   <dependencies>
     <dependency>
-      <groupId>org.codehaus.plexus</groupId>
-      <artifactId>plexus-container-default</artifactId>
+      <groupId>org.eclipse.sisu</groupId>
+      <artifactId>org.eclipse.sisu.plexus</artifactId>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.google.inject</groupId>
+      <artifactId>guice</artifactId>
+      <classifier>classes</classifier>
       <scope>compile</scope>
     </dependency>
     <dependency>

--- a/wagon-providers/wagon-ssh/pom.xml
+++ b/wagon-providers/wagon-ssh/pom.xml
@@ -82,8 +82,14 @@ under the License.
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.codehaus.plexus</groupId>
-      <artifactId>plexus-container-default</artifactId>
+      <groupId>org.eclipse.sisu</groupId>
+      <artifactId>org.eclipse.sisu.plexus</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.google.inject</groupId>
+      <artifactId>guice</artifactId>
+      <classifier>classes</classifier>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/wagon-tcks/wagon-tck-http/pom.xml
+++ b/wagon-tcks/wagon-tck-http/pom.xml
@@ -33,8 +33,14 @@ under the License.
 
   <dependencies>
     <dependency>
-      <groupId>org.codehaus.plexus</groupId>
-      <artifactId>plexus-container-default</artifactId>
+      <groupId>org.eclipse.sisu</groupId>
+      <artifactId>org.eclipse.sisu.plexus</artifactId>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.google.inject</groupId>
+      <artifactId>guice</artifactId>
+      <classifier>classes</classifier>
       <scope>compile</scope>
     </dependency>
     <dependency>

--- a/wagon-tcks/wagon-tck-http/sample-tck-consumer/src/test/resources/META-INF/plexus/components.xml
+++ b/wagon-tcks/wagon-tck-http/sample-tck-consumer/src/test/resources/META-INF/plexus/components.xml
@@ -25,14 +25,7 @@ under the License.
       <implementation>org.apache.maven.wagon.tck.http.WagonTestCaseConfigurator</implementation>
       <configuration>
         <wagonHint>http</wagonHint>
-        <useCaseConfigs>
-          <highLatencyLowTimeout>
-            <unsupported/>
-          </highLatencyLowTimeout>
-          <inifiniteLatencyTimeout>
-            <unsupported/>
-          </inifiniteLatencyTimeout>
-        </useCaseConfigs>
+        <useCaseConfigsResource>META-INF/wagon-tck/http-use-cases.xml</useCaseConfigsResource>
       </configuration>
     </component>
   </components>

--- a/wagon-tcks/wagon-tck-http/sample-tck-consumer/src/test/resources/META-INF/wagon-tck/http-use-cases.xml
+++ b/wagon-tcks/wagon-tck-http/sample-tck-consumer/src/test/resources/META-INF/wagon-tck/http-use-cases.xml
@@ -1,0 +1,26 @@
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-->
+<useCaseConfigs>
+  <highLatencyLowTimeout>
+    <unsupported/>
+  </highLatencyLowTimeout>
+  <inifiniteLatencyTimeout>
+    <unsupported/>
+  </inifiniteLatencyTimeout>
+</useCaseConfigs>

--- a/wagon-tcks/wagon-tck-http/src/main/java/org/apache/maven/wagon/tck/http/WagonTestCaseConfigurator.java
+++ b/wagon-tcks/wagon-tck-http/src/main/java/org/apache/maven/wagon/tck/http/WagonTestCaseConfigurator.java
@@ -18,17 +18,26 @@
  */
 package org.apache.maven.wagon.tck.http;
 
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.Reader;
+import java.nio.charset.StandardCharsets;
+
 import org.apache.maven.wagon.Wagon;
 import org.codehaus.plexus.PlexusConstants;
 import org.codehaus.plexus.PlexusContainer;
 import org.codehaus.plexus.classworlds.realm.ClassRealm;
+import org.codehaus.plexus.component.configurator.BasicComponentConfigurator;
 import org.codehaus.plexus.component.configurator.ComponentConfigurationException;
 import org.codehaus.plexus.component.configurator.ComponentConfigurator;
-import org.codehaus.plexus.component.repository.exception.ComponentLookupException;
 import org.codehaus.plexus.configuration.PlexusConfiguration;
+import org.codehaus.plexus.configuration.xml.XmlPlexusConfiguration;
 import org.codehaus.plexus.context.Context;
 import org.codehaus.plexus.context.ContextException;
 import org.codehaus.plexus.personality.plexus.lifecycle.phase.Contextualizable;
+import org.codehaus.plexus.util.xml.Xpp3DomBuilder;
+import org.codehaus.plexus.util.xml.pull.XmlPullParserException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -38,7 +47,15 @@ import org.slf4j.LoggerFactory;
 public class WagonTestCaseConfigurator implements Contextualizable {
     private static final String UNSUPPORTED_ELEMENT = "unsupported";
 
-    private PlexusConfiguration useCaseConfigs;
+    /**
+     * Classpath location of the per-use-case configuration, e.g.
+     * {@code META-INF/wagon-tck/http-use-cases.xml}. The Plexus shim cannot inject a nested XML tree into a
+     * {@link PlexusConfiguration} field, so the configuration lives in its own resource and is parsed on
+     * demand by {@link #getUseCaseConfigs()}.
+     */
+    private String useCaseConfigsResource;
+
+    private PlexusConfiguration useCaseConfigsDom;
 
     private ComponentConfigurator configurator;
 
@@ -49,6 +66,7 @@ public class WagonTestCaseConfigurator implements Contextualizable {
     private static Logger logger = LoggerFactory.getLogger(WagonTestCaseConfigurator.class);
 
     public boolean isSupported(final String useCaseId) {
+        PlexusConfiguration useCaseConfigs = getUseCaseConfigs();
         if (useCaseConfigs != null) {
             PlexusConfiguration config = useCaseConfigs.getChild(useCaseId, false);
 
@@ -63,6 +81,7 @@ public class WagonTestCaseConfigurator implements Contextualizable {
 
     public boolean configureWagonForTest(final Wagon wagon, final String useCaseId)
             throws ComponentConfigurationException {
+        PlexusConfiguration useCaseConfigs = getUseCaseConfigs();
         if (useCaseConfigs != null) {
             PlexusConfiguration config = useCaseConfigs.getChild(useCaseId, false);
 
@@ -87,19 +106,33 @@ public class WagonTestCaseConfigurator implements Contextualizable {
     public void contextualize(final Context context) throws ContextException {
         PlexusContainer container = (PlexusContainer) context.get(PlexusConstants.PLEXUS_KEY);
         this.realm = container.getContainerRealm();
-        try {
-            configurator = (ComponentConfigurator) container.lookup(ComponentConfigurator.ROLE);
-        } catch (ComponentLookupException e) {
-            throw new ContextException("Failed to lookup component configurator: " + e.getMessage(), e);
-        }
+        // The Plexus shim does not register a default ComponentConfigurator component, and the TCK only ever
+        // wants the basic one, so instantiate it directly rather than looking it up.
+        configurator = new BasicComponentConfigurator();
     }
 
     public PlexusConfiguration getUseCaseConfigs() {
-        return useCaseConfigs;
+        if (useCaseConfigsDom == null && useCaseConfigsResource != null) {
+            ClassLoader loader = Thread.currentThread().getContextClassLoader();
+            try (InputStream in = loader.getResourceAsStream(useCaseConfigsResource)) {
+                if (in == null) {
+                    throw new IllegalStateException(
+                            "TCK use-case configuration not found on the classpath: " + useCaseConfigsResource);
+                }
+
+                Reader reader = new InputStreamReader(in, StandardCharsets.UTF_8);
+                useCaseConfigsDom = new XmlPlexusConfiguration(Xpp3DomBuilder.build(reader));
+            } catch (XmlPullParserException | IOException e) {
+                throw new IllegalStateException("Malformed TCK use-case configuration: " + useCaseConfigsResource, e);
+            }
+        }
+
+        return useCaseConfigsDom;
     }
 
-    public void setUseCaseConfigs(final PlexusConfiguration useCaseConfigs) {
-        this.useCaseConfigs = useCaseConfigs;
+    public void setUseCaseConfigsResource(final String useCaseConfigsResource) {
+        this.useCaseConfigsResource = useCaseConfigsResource;
+        this.useCaseConfigsDom = null;
     }
 
     public String getWagonHint() {


### PR DESCRIPTION
Groundwork for moving Wagon off Plexus and onto JSR-330. This PR only swaps the
container; the `@plexus.component` javadoc tags are untouched and follow in a
second PR.

`plexus-container-default` is the original Plexus container and cannot read
`META-INF/sisu` indexes, so nothing can become `@Named` while it is in place.
`org.eclipse.sisu.plexus` supplies `PlexusContainer` and `PlexusTestCase` and reads
both component descriptors and annotated beans, so it is the natural replacement.

It reads `META-INF/plexus/components.xml` with classpath scanning off, which is why
this PR stands alone: every existing descriptor keeps working untouched.

### Why now

`maven-parent` 49 bans `plexus-container-default` in its `drop-legacy-dependencies`
profile. That profile has no activation today, so `master` still builds for CI --
this is preparation for the ban becoming unconditional, not a fix for a broken build.

### The swap was not a drop-in

Four behavioural differences between the shim and the original container turned up
only by building the whole reactor, and each has its own commit:

1. **Nested XML configuration cannot be injected.** `WagonTestCaseConfigurator` took
   its per-use-case configuration as a `<useCaseConfigs>` tree inside the descriptor.
   Asking for a `PlexusConfiguration` fails to convert; asking for a `String` yields
   only the element's text content, which is empty. The configuration now lives in its
   own classpath resource, with the descriptor holding a plain string path. The
   configuration itself is unchanged. **This changes how TCK consumers configure use
   cases**, which is the one deliberate compatibility break here -- all three in-tree
   consumers are updated.
2. **No default `ComponentConfigurator` is registered.** `lookup(ComponentConfigurator.ROLE)`
   fails; `BasicComponentConfigurator` ships in the Sisu jar and is now instantiated
   directly.
3. **`maven-scm-manager-plexus` drags in `plexus-container-default` 1.0-alpha-9**, putting
   a second `PlexusContainer`/`PlexusTestCase` on the wagon-scm test classpath. The
   alpha-9 copy won and its `tearDown` is not null-guarded, so every test failed with an
   NPE that hid the real cause. Now excluded.
4. **Requirement maps are injected immutable.** `AbstractScmManager.setScmProvider` does a
   `put` on its provider map, so every wagon-scm test that forces a particular provider
   implementation failed in `setUp`. The test now installs a mutable copy first.

`WagonTestCase.customizeContext()` is deleted rather than adapted: the no-argument
signature never overrode `PlexusTestCase.customizeContext(Context)` in either container,
so it has never been called and the value it set is read nowhere.

### Status

Full reactor green, all 17 modules, including the HTTP TCK (40 tests, plus the 2
correctly skipped as unsupported) and wagon-scm.

Not for `wagon-3.x` -- this belongs to the 4.0.0 line.
