### PR TITLE
Migrate the standalone provider tests to JUnit 5

### DIFF
--- a/wagon-providers/wagon-http-shared/pom.xml
+++ b/wagon-providers/wagon-http-shared/pom.xml
@@ -59,8 +59,8 @@ under the License.
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/wagon-providers/wagon-http-shared/src/test/java/org/apache/maven/wagon/shared/http/EncodingUtilTest.java
+++ b/wagon-providers/wagon-http-shared/src/test/java/org/apache/maven/wagon/shared/http/EncodingUtilTest.java
@@ -21,33 +21,40 @@ package org.apache.maven.wagon.shared.http;
 import java.net.MalformedURLException;
 import java.net.URISyntaxException;
 
-import junit.framework.TestCase;
+import org.junit.jupiter.api.Test;
 
-public class EncodingUtilTest extends TestCase {
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class EncodingUtilTest {
+    @Test
     public void testEncodeURLWithTrailingSlash() {
         String encodedURL = EncodingUtil.encodeURLToString("https://host:1234/test", "demo/");
 
         assertEquals("https://host:1234/test/demo/", encodedURL);
     }
 
+    @Test
     public void testEncodeURLWithSpaces() throws URISyntaxException, MalformedURLException {
         String encodedURL = EncodingUtil.encodeURLToString("file://host:1/path with spaces");
 
         assertEquals("file://host:1/path%20with%20spaces", encodedURL);
     }
 
+    @Test
     public void testEncodeURLWithSpacesInPath() throws URISyntaxException, MalformedURLException {
         String encodedURL = EncodingUtil.encodeURLToString("file://host:1", "path with spaces");
 
         assertEquals("file://host:1/path%20with%20spaces", encodedURL);
     }
 
+    @Test
     public void testEncodeURLWithSpacesInBothBaseAndPath() throws URISyntaxException, MalformedURLException {
         String encodedURL = EncodingUtil.encodeURLToString("file://host:1/with%20a", "path with spaces");
 
         assertEquals("file://host:1/with%20a/path%20with%20spaces", encodedURL);
     }
 
+    @Test
     public void testEncodeURLWithSlashes1() throws URISyntaxException, MalformedURLException {
         String encodedURL = EncodingUtil.encodeURLToString("file://host:1/basePath", "a", "b", "c");
 
@@ -58,6 +65,7 @@ public class EncodingUtilTest extends TestCase {
         assertEquals("file://host:1/basePath/a/b/c", encodedURL);
     }
 
+    @Test
     public void testEncodeURLWithSlashes2() throws URISyntaxException, MalformedURLException {
         String encodedURL = EncodingUtil.encodeURLToString("file://host:1/basePath/", "a", "b", "c");
 
@@ -68,36 +76,42 @@ public class EncodingUtilTest extends TestCase {
         assertEquals("file://host:1/basePath/a/b/c", encodedURL);
     }
 
+    @Test
     public void testEncodeURLWithSlashes3() throws URISyntaxException, MalformedURLException {
         String encodedURL = EncodingUtil.encodeURLToString("file://host:1/basePath/", new String[0]);
 
         assertEquals("file://host:1/basePath/", encodedURL);
     }
 
+    @Test
     public void testEncodeURLWithSlashes4() throws URISyntaxException, MalformedURLException {
         String encodedURL = EncodingUtil.encodeURLToString("file://host:1/basePath", new String[0]);
 
         assertEquals("file://host:1/basePath", encodedURL);
     }
 
+    @Test
     public void testEncodeURLWithSlashes5() throws URISyntaxException, MalformedURLException {
         String encodedURL = EncodingUtil.encodeURLToString("file://host:1/basePath", "a/1", "b/1", "c/1");
 
         assertEquals("file://host:1/basePath/a%2F1/b%2F1/c%2F1", encodedURL);
     }
 
+    @Test
     public void testEncodeURLWithSlashes6() throws URISyntaxException, MalformedURLException {
         String encodedURL = EncodingUtil.encodeURLToString("file://host:1/", new String[0]);
 
         assertEquals("file://host:1/", encodedURL);
     }
 
+    @Test
     public void testEncodeURLWithSlashes7() throws URISyntaxException, MalformedURLException {
         String encodedURL = EncodingUtil.encodeURLToString("file://host:1", new String[0]);
 
         assertEquals("file://host:1", encodedURL);
     }
 
+    @Test
     public void testEncodeURLWithNonLatin() throws URISyntaxException, MalformedURLException {
         String encodedURL = EncodingUtil.encodeURLToString("file://host:1", "пипец/");
 

--- a/wagon-providers/wagon-ssh-common/pom.xml
+++ b/wagon-providers/wagon-ssh-common/pom.xml
@@ -39,8 +39,8 @@ under the License.
       <artifactId>plexus-interactivity-api</artifactId>
     </dependency>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/wagon-providers/wagon-ssh-common/src/test/java/org/apache/maven/wagon/providers/ssh/LSParserTest.java
+++ b/wagon-providers/wagon-ssh-common/src/test/java/org/apache/maven/wagon/providers/ssh/LSParserTest.java
@@ -20,10 +20,15 @@ package org.apache.maven.wagon.providers.ssh;
 
 import java.util.List;
 
-import junit.framework.TestCase;
 import org.apache.maven.wagon.TransferFailedException;
+import org.junit.jupiter.api.Test;
 
-public class LSParserTest extends TestCase {
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class LSParserTest {
+    @Test
     public void testParseLinux() throws TransferFailedException {
         String rawLS = "total 32\n" + "drwxr-xr-x  5 joakim joakim 4096 2006-12-11 10:30 .\n"
                 + "drwxr-xr-x 14 joakim joakim 4096 2006-12-11 10:30 ..\n"
@@ -43,6 +48,7 @@ public class LSParserTest extends TestCase {
         assertTrue(files.contains("spaced out"));
     }
 
+    @Test
     public void testParseOSX() throws TransferFailedException {
         String rawLS = "total 32\n" + "drwxr-xr-x   5  joakim  joakim   238 Dec 11 10:30 .\n"
                 + "drwxr-xr-x  14  joakim  joakim   518 Dec 11 10:30 ..\n"
@@ -62,6 +68,7 @@ public class LSParserTest extends TestCase {
         assertTrue(files.contains("spaced out"));
     }
 
+    @Test
     public void testParseOSXFrLocale() throws TransferFailedException {
         String rawLS = "total 40\n" + "-rw-r--r--  1 olamy  staff  11 21 sep 00:34 .index.txt\n"
                 + "-rw-r--r--  1 olamy  staff  19 21 sep 00:34 more-resources.dat\n"
@@ -77,6 +84,7 @@ public class LSParserTest extends TestCase {
         assertTrue(files.contains(".index.txt"));
     }
 
+    @Test
     public void testParseCygwin() throws TransferFailedException {
         String rawLS = "total 32\n" + "drwxr-xr-x+  5 joakim None    0 Dec 11 10:30 .\n"
                 + "drwxr-xr-x+ 14 joakim None    0 Dec 11 10:30 ..\n"
@@ -101,6 +109,7 @@ public class LSParserTest extends TestCase {
      * Just adding a real-world example of the ls to see if it is a problem.
      *   - Joakime
      */
+    @Test
     public void testParsePeopleApacheStaging() throws TransferFailedException {
         String rawLS = "total 6\n"
                 + "drwxr-xr-x  3 snicoll  snicoll  512 Feb  7 11:04 .\n"

--- a/wagon-providers/wagon-ssh-common/src/test/java/org/apache/maven/wagon/providers/ssh/knownhost/FileKnownHostsProviderTest.java
+++ b/wagon-providers/wagon-ssh-common/src/test/java/org/apache/maven/wagon/providers/ssh/knownhost/FileKnownHostsProviderTest.java
@@ -22,18 +22,21 @@ import java.io.File;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 
-import junit.framework.TestCase;
 import org.codehaus.plexus.util.FileUtils;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
-public class FileKnownHostsProviderTest extends TestCase {
+public class FileKnownHostsProviderTest {
     private File basedir = new File(System.getProperty("basedir", "."));
 
     private File testKnownHostsFile;
 
     private FileKnownHostsProvider provider;
 
+    @BeforeEach
     public void setUp() throws Exception {
         File readonlyKnownHostFile = new File(basedir, "src/test/resources/known_hosts");
         testKnownHostsFile = new File(basedir, "target/known_hosts");
@@ -44,6 +47,7 @@ public class FileKnownHostsProviderTest extends TestCase {
         provider = new FileKnownHostsProvider(testKnownHostsFile);
     }
 
+    @Test
     public void testStoreKnownHostsNoChange() throws Exception {
         long timestamp = this.testKnownHostsFile.lastModified();
         // file with the same contents, but with entries swapped
@@ -51,9 +55,10 @@ public class FileKnownHostsProviderTest extends TestCase {
         String contents = new String(Files.readAllBytes(sameKnownHostFile.toPath()), StandardCharsets.US_ASCII);
 
         provider.storeKnownHosts(contents);
-        assertEquals("known_hosts file is rewritten", timestamp, testKnownHostsFile.lastModified());
+        assertEquals(timestamp, testKnownHostsFile.lastModified(), "known_hosts file is rewritten");
     }
 
+    @Test
     public void testStoreKnownHostsWithChange() throws Exception {
         long timestamp = this.testKnownHostsFile.lastModified();
         File sameKnownHostFile = new File(basedir, "src/test/resources/known_hosts_same");
@@ -61,6 +66,6 @@ public class FileKnownHostsProviderTest extends TestCase {
         contents += "1 2 3";
 
         provider.storeKnownHosts(contents);
-        assertNotEquals("known_hosts file is not rewritten", timestamp, testKnownHostsFile.lastModified());
+        assertNotEquals(timestamp, testKnownHostsFile.lastModified(), "known_hosts file is not rewritten");
     }
 }

--- a/wagon-providers/wagon-webdav-jackrabbit/pom.xml
+++ b/wagon-providers/wagon-webdav-jackrabbit/pom.xml
@@ -86,6 +86,17 @@ under the License.
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <!-- WebDavWagonTest and its subclasses inherit JUnit 4 tests from the published HttpWagonTestCase -->
+    <dependency>
+      <groupId>org.junit.vintage</groupId>
+      <artifactId>junit-vintage-engine</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.eclipse.jetty.aggregate</groupId>
       <artifactId>jetty-all</artifactId>
       <scope>test</scope>

--- a/wagon-providers/wagon-webdav-jackrabbit/src/test/java/org/apache/maven/wagon/providers/webdav/HttpClientWagonTest.java
+++ b/wagon-providers/wagon-webdav-jackrabbit/src/test/java/org/apache/maven/wagon/providers/webdav/HttpClientWagonTest.java
@@ -18,7 +18,6 @@
  */
 package org.apache.maven.wagon.providers.webdav;
 
-import junit.framework.TestCase;
 import org.apache.http.Header;
 import org.apache.http.client.methods.HttpHead;
 import org.apache.http.params.HttpParams;
@@ -31,9 +30,15 @@ import org.apache.maven.wagon.proxy.ProxyInfo;
 import org.apache.maven.wagon.repository.Repository;
 import org.apache.maven.wagon.shared.http.HttpConfiguration;
 import org.apache.maven.wagon.shared.http.HttpMethodConfiguration;
+import org.junit.jupiter.api.Test;
 
-public class HttpClientWagonTest extends TestCase {
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
+public class HttpClientWagonTest {
+
+    @Test
     public void testSetPreemptiveAuthParamViaConfig() {
         HttpMethodConfiguration methodConfig = new HttpMethodConfiguration();
         methodConfig.setUsePreemptive(true);
@@ -51,6 +56,7 @@ public class HttpClientWagonTest extends TestCase {
         assertNotNull(params);
     }
 
+    @Test
     public void testDefaultHeadersUsedByDefault() {
         HttpConfiguration config = new HttpConfiguration();
         config.setAll(new HttpMethodConfiguration());
@@ -75,6 +81,7 @@ public class HttpClientWagonTest extends TestCase {
         assertEquals("no-cache", header.getValue());
     }
 
+    @Test
     public void testTurnOffDefaultHeaders() {
         HttpConfiguration config = new HttpConfiguration();
         config.setAll(new HttpMethodConfiguration().setUseDefaultHeaders(false));
@@ -96,6 +103,7 @@ public class HttpClientWagonTest extends TestCase {
         assertNull(header);
     }
 
+    @Test
     public void testNTCredentialsWithUsernameNull() throws AuthenticationException, ConnectionException {
         TestWagon wagon = new TestWagon();
 
@@ -108,6 +116,7 @@ public class HttpClientWagonTest extends TestCase {
         assertNull(wagon.getAuthenticationInfo().getPassword());
     }
 
+    @Test
     public void testNTCredentialsNoNTDomain() throws AuthenticationException, ConnectionException {
         TestWagon wagon = new TestWagon();
 
@@ -128,6 +137,7 @@ public class HttpClientWagonTest extends TestCase {
         assertEquals(myPassword, wagon.getAuthenticationInfo().getPassword());
     }
 
+    @Test
     public void testNTCredentialsWithNTDomain() throws AuthenticationException, ConnectionException {
         TestWagon wagon = new TestWagon();
 

--- a/wagon-providers/wagon-webdav-jackrabbit/src/test/java/org/apache/maven/wagon/providers/webdav/MultiStatusTest.java
+++ b/wagon-providers/wagon-webdav-jackrabbit/src/test/java/org/apache/maven/wagon/providers/webdav/MultiStatusTest.java
@@ -23,12 +23,12 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * Tests for parsing {@code 207 Multi-Status} PROPFIND responses.
@@ -133,7 +133,7 @@ public class MultiStatusTest {
 
         assertEquals(2, responses.size());
         assertEquals("/repo/dir/a", responses.get(0).getHref());
-        assertTrue("the later duplicate wins", responses.get(0).isCollection());
+        assertTrue(responses.get(0).isCollection(), "the later duplicate wins");
         assertEquals("/repo/dir/b", responses.get(1).getHref());
     }
 

--- a/wagon-providers/wagon-webdav-jackrabbit/src/test/java/org/apache/maven/wagon/providers/webdav/PathNavigatorTest.java
+++ b/wagon-providers/wagon-webdav-jackrabbit/src/test/java/org/apache/maven/wagon/providers/webdav/PathNavigatorTest.java
@@ -18,14 +18,19 @@
  */
 package org.apache.maven.wagon.providers.webdav;
 
-import junit.framework.TestCase;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * @author <a href="mailto:james@atlassian.com">James William Dumay</a>
  */
-public class PathNavigatorTest extends TestCase {
+public class PathNavigatorTest {
     private static final String TEST_PATH = "foo/bar/baz";
 
+    @Test
     public void testBackAndForward() {
         PathNavigator navigator = new PathNavigator(TEST_PATH);
 


### PR DESCRIPTION
The part of wagon's JUnit 4 tail that needs no decision. Six tests across three provider modules extend `junit.framework.TestCase` or import `org.junit` directly and depend on nothing else, so they can move on their own.

| module | migrated | JUnit 4 after |
|---|---|---|
| `wagon-http-shared` | `EncodingUtilTest` | none — `junit:junit` removed |
| `wagon-ssh-common` | `LSParserTest`, `FileKnownHostsProviderTest` | none — `junit:junit` removed |
| `wagon-webdav-jackrabbit` | `HttpClientWagonTest`, `MultiStatusTest`, `PathNavigatorTest` | `WebDavWagonTest` + 3 subclasses |

**Why webdav keeps `junit:junit`.** `WebDavWagonTest` and its three subclasses inherit their tests from `HttpWagonTestCase`, which lives in `wagon-provider-test`'s **published** API and still extends `PlexusTestCase` — that inheritance is where the module's 295 tests come from. They cannot move until the base class does, so `junit-vintage-engine` is added to keep them discoverable now that surefire selects the JUnit Platform provider for the module. That dependency comes back out when the base classes migrate.

**Nothing a third party can extend is touched here**, which is the point of the split: this needs no decision about the published test-support artifacts.

### What is deliberately not in this PR

- `wagon-provider-test` (`WagonTestCase`, `StreamingWagonTestCase`, `HttpWagonTestCase`), `wagon-ssh-common-test` (`KnownHostsProviderTestCase`) and `wagon-tck-http` (`Assertions`, `GetWagonTests`, `HttpWagonTests`) are all `src/main/java` of published artifacts that third-party wagon providers extend. Migrating them breaks those consumers at compile time on the 3.x line, which wants a dev@ decision first.
- The three `@RunWith(Suite.class)` aggregators (`wagon-http/TckTest`, `wagon-http-lightweight/TckTest`, `sample-tck-consumer/TestSuite`) name `GetWagonTests` directly, so they are bound to the same question rather than independent of it.
- `wagon-http`'s three standalone unit tests are held back on purpose: that module also holds the TCK suite and two `PlexusTestCase` tests, so migrating it piecemeal would mean adding a vintage engine there that gets removed again shortly. Happy to fold them in if you would rather.

### Verification

`mvn test` per module, before and after — identical:

```
wagon-http-shared         12 -> 12
wagon-ssh-common           7 ->  7
wagon-webdav-jackrabbit  295 -> 295
```

Surefire switches from `JUnit4Provider` to `JUnitPlatformProvider`, confirming these really run under Jupiter and that the vintage engine keeps webdav's 295 alive.

Matching counts alone would not prove the assertions still assert, so one was checked negatively: corrupting an expected value in `EncodingUtilTest` yields `org.opentest4j.AssertionFailedError: expected: <ZZZ_WRONG> but was: <https://host:1234/test/demo/>` — an opentest4j failure, so it is the Jupiter path doing the work.

`spotless:check` clean. Draft until CI confirms.

Generated-by: Claude Opus 5 (1M context)
