### PR TITLE
[wagon-3.x] Replace the Plexus javadoc tags with JSR-330 annotations

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -295,7 +295,13 @@ under the License.
         </plugin>
       </plugins>
     </pluginManagement>
-
+    <plugins>
+      <!-- indexes the @Named beans into META-INF/sisu; executions come from maven-parent -->
+      <plugin>
+        <groupId>org.eclipse.sisu</groupId>
+        <artifactId>sisu-maven-plugin</artifactId>
+      </plugin>
+    </plugins>
   </build>
 
   <profiles>

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@ under the License.
 
   <groupId>org.apache.maven.wagon</groupId>
   <artifactId>wagon</artifactId>
-  <version>3.5.4-SNAPSHOT</version>
+  <version>3.6.0-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <name>Apache Maven Wagon</name>

--- a/wagon-provider-api/pom.xml
+++ b/wagon-provider-api/pom.xml
@@ -23,7 +23,7 @@ under the License.
   <parent>
     <groupId>org.apache.maven.wagon</groupId>
     <artifactId>wagon</artifactId>
-    <version>3.5.4-SNAPSHOT</version>
+    <version>3.6.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>wagon-provider-api</artifactId>

--- a/wagon-provider-test/pom.xml
+++ b/wagon-provider-test/pom.xml
@@ -23,7 +23,7 @@ under the License.
   <parent>
     <groupId>org.apache.maven.wagon</groupId>
     <artifactId>wagon</artifactId>
-    <version>3.5.4-SNAPSHOT</version>
+    <version>3.6.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>wagon-provider-test</artifactId>

--- a/wagon-provider-test/src/main/java/org/apache/maven/wagon/CommandExecutorTestCase.java
+++ b/wagon-provider-test/src/main/java/org/apache/maven/wagon/CommandExecutorTestCase.java
@@ -20,6 +20,8 @@ package org.apache.maven.wagon;
 
 import org.apache.maven.wagon.authentication.AuthenticationInfo;
 import org.apache.maven.wagon.repository.Repository;
+import org.codehaus.plexus.ContainerConfiguration;
+import org.codehaus.plexus.PlexusConstants;
 import org.codehaus.plexus.PlexusTestCase;
 
 /**
@@ -29,6 +31,12 @@ import org.codehaus.plexus.PlexusTestCase;
  *
  */
 public abstract class CommandExecutorTestCase extends PlexusTestCase {
+    @Override
+    protected void customizeContainerConfiguration(ContainerConfiguration configuration) {
+        // the providers are @Named beans now, so the container has to read META-INF/sisu
+        configuration.setClassPathScanning(PlexusConstants.SCANNING_INDEX);
+    }
+
     public void testErrorInCommandExecuted() throws Exception {
         CommandExecutor exec = (CommandExecutor) lookup(CommandExecutor.ROLE);
 

--- a/wagon-provider-test/src/main/java/org/apache/maven/wagon/WagonTestCase.java
+++ b/wagon-provider-test/src/main/java/org/apache/maven/wagon/WagonTestCase.java
@@ -37,6 +37,8 @@ import org.apache.maven.wagon.observers.Debug;
 import org.apache.maven.wagon.repository.Repository;
 import org.apache.maven.wagon.repository.RepositoryPermissions;
 import org.apache.maven.wagon.resource.Resource;
+import org.codehaus.plexus.ContainerConfiguration;
+import org.codehaus.plexus.PlexusConstants;
 import org.codehaus.plexus.PlexusTestCase;
 import org.codehaus.plexus.util.FileUtils;
 import org.junit.Assume;
@@ -55,6 +57,12 @@ import static org.mockito.Mockito.mock;
  * @author <a href="mailto:jason@maven.org">Jason van Zyl</a>
  */
 public abstract class WagonTestCase extends PlexusTestCase {
+    @Override
+    protected void customizeContainerConfiguration(ContainerConfiguration configuration) {
+        // the providers are @Named beans now, so the container has to read META-INF/sisu
+        configuration.setClassPathScanning(PlexusConstants.SCANNING_INDEX);
+    }
+
     protected static Logger logger = LoggerFactory.getLogger(WagonTestCase.class);
 
     static final class ProgressAnswer implements Answer<Object> {

--- a/wagon-providers/pom.xml
+++ b/wagon-providers/pom.xml
@@ -23,7 +23,7 @@ under the License.
   <parent>
     <groupId>org.apache.maven.wagon</groupId>
     <artifactId>wagon</artifactId>
-    <version>3.5.4-SNAPSHOT</version>
+    <version>3.6.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>wagon-providers</artifactId>

--- a/wagon-providers/pom.xml
+++ b/wagon-providers/pom.xml
@@ -65,37 +65,19 @@ under the License.
       <artifactId>wagon-provider-api</artifactId>
     </dependency>
     <dependency>
+      <groupId>javax.inject</groupId>
+      <artifactId>javax.inject</artifactId>
+      <version>1</version>
+    </dependency>
+    <!-- for @Typed, where a provider implements more roles than it is published under -->
+    <dependency>
+      <groupId>org.eclipse.sisu</groupId>
+      <artifactId>org.eclipse.sisu.inject</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.apache.maven.wagon</groupId>
       <artifactId>wagon-provider-test</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>
-
-  <build>
-    <pluginManagement>
-      <plugins>
-        <!-- required due to Javadoc based Plexus components -->
-        <plugin>
-          <groupId>org.codehaus.plexus</groupId>
-          <artifactId>plexus-component-metadata</artifactId>
-          <version>2.2.0</version>
-          <executions>
-            <execution>
-              <id>generate</id>
-              <goals>
-                <goal>generate-metadata</goal>
-              </goals>
-            </execution>
-          </executions>
-        </plugin>
-      </plugins>
-    </pluginManagement>
-
-    <plugins>
-      <plugin>
-        <groupId>org.eclipse.sisu</groupId>
-        <artifactId>sisu-maven-plugin</artifactId>
-      </plugin>
-    </plugins>
-  </build>
 </project>

--- a/wagon-providers/wagon-file/pom.xml
+++ b/wagon-providers/wagon-file/pom.xml
@@ -23,7 +23,7 @@ under the License.
   <parent>
     <groupId>org.apache.maven.wagon</groupId>
     <artifactId>wagon-providers</artifactId>
-    <version>3.5.4-SNAPSHOT</version>
+    <version>3.6.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>wagon-file</artifactId>

--- a/wagon-providers/wagon-file/pom.xml
+++ b/wagon-providers/wagon-file/pom.xml
@@ -41,13 +41,4 @@ under the License.
       <scope>test</scope>
     </dependency>
   </dependencies>
-
-  <build>
-    <plugins>
-      <plugin>
-        <groupId>org.codehaus.plexus</groupId>
-        <artifactId>plexus-component-metadata</artifactId>
-      </plugin>
-    </plugins>
-  </build>
 </project>

--- a/wagon-providers/wagon-file/src/main/java/org/apache/maven/wagon/providers/file/FileWagon.java
+++ b/wagon-providers/wagon-file/src/main/java/org/apache/maven/wagon/providers/file/FileWagon.java
@@ -18,6 +18,8 @@
  */
 package org.apache.maven.wagon.providers.file;
 
+import javax.inject.Named;
+
 import java.io.BufferedInputStream;
 import java.io.BufferedOutputStream;
 import java.io.File;
@@ -45,8 +47,8 @@ import org.codehaus.plexus.util.FileUtils;
  *
  * @author <a href="michal.maczka@dimatics.com">Michal Maczka</a>
  *
- * @plexus.component role="org.apache.maven.wagon.Wagon" role-hint="file" instantiation-strategy="per-lookup"
  */
+@Named("file")
 public class FileWagon extends StreamWagon {
     public void fillInputData(InputData inputData) throws TransferFailedException, ResourceDoesNotExistException {
         if (getRepository().getBasedir() == null) {

--- a/wagon-providers/wagon-ftp/pom.xml
+++ b/wagon-providers/wagon-ftp/pom.xml
@@ -57,13 +57,4 @@ under the License.
       <artifactId>commons-io</artifactId>
     </dependency>
   </dependencies>
-
-  <build>
-    <plugins>
-      <plugin>
-        <groupId>org.codehaus.plexus</groupId>
-        <artifactId>plexus-component-metadata</artifactId>
-      </plugin>
-    </plugins>
-  </build>
 </project>

--- a/wagon-providers/wagon-ftp/pom.xml
+++ b/wagon-providers/wagon-ftp/pom.xml
@@ -23,7 +23,7 @@ under the License.
   <parent>
     <groupId>org.apache.maven.wagon</groupId>
     <artifactId>wagon-providers</artifactId>
-    <version>3.5.4-SNAPSHOT</version>
+    <version>3.6.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>wagon-ftp</artifactId>

--- a/wagon-providers/wagon-ftp/src/main/java/org/apache/maven/wagon/providers/ftp/FtpHttpWagon.java
+++ b/wagon-providers/wagon-ftp/src/main/java/org/apache/maven/wagon/providers/ftp/FtpHttpWagon.java
@@ -18,6 +18,8 @@
  */
 package org.apache.maven.wagon.providers.ftp;
 
+import javax.inject.Named;
+
 import org.apache.commons.net.ftp.FTPClient;
 import org.apache.commons.net.ftp.FTPHTTPClient;
 import org.apache.maven.wagon.proxy.ProxyInfo;
@@ -28,10 +30,8 @@ import org.slf4j.LoggerFactory;
  * FtpHttpWagon
  *
  *
- * @plexus.component role="org.apache.maven.wagon.Wagon"
- * role-hint="ftph"
- * instantiation-strategy="per-lookup"
  */
+@Named("ftph")
 public class FtpHttpWagon extends FtpWagon {
 
     private static final Logger LOG = LoggerFactory.getLogger(FtpHttpWagon.class);

--- a/wagon-providers/wagon-ftp/src/main/java/org/apache/maven/wagon/providers/ftp/FtpWagon.java
+++ b/wagon-providers/wagon-ftp/src/main/java/org/apache/maven/wagon/providers/ftp/FtpWagon.java
@@ -18,6 +18,8 @@
  */
 package org.apache.maven.wagon.providers.ftp;
 
+import javax.inject.Named;
+
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
@@ -52,21 +54,13 @@ import org.apache.maven.wagon.resource.Resource;
  * FtpWagon
  *
  *
- * @plexus.component role="org.apache.maven.wagon.Wagon"
- * role-hint="ftp"
- * instantiation-strategy="per-lookup"
  */
+@Named("ftp")
 public class FtpWagon extends StreamWagon {
     private FTPClient ftp;
 
-    /**
-     * @plexus.configuration default-value="true"
-     */
     private boolean passiveMode = true;
 
-    /**
-     * @plexus.configuration default-value="ISO-8859-1"
-     */
     private String controlEncoding = FTP.DEFAULT_CONTROL_ENCODING;
 
     public boolean isPassiveMode() {
@@ -345,9 +339,6 @@ public class FtpWagon extends StreamWagon {
         }
     }
 
-    /**
-     *
-     */
     public class PrintCommandListener implements ProtocolCommandListener {
         private FtpWagon wagon;
 

--- a/wagon-providers/wagon-ftp/src/main/java/org/apache/maven/wagon/providers/ftp/FtpsWagon.java
+++ b/wagon-providers/wagon-ftp/src/main/java/org/apache/maven/wagon/providers/ftp/FtpsWagon.java
@@ -18,6 +18,8 @@
  */
 package org.apache.maven.wagon.providers.ftp;
 
+import javax.inject.Named;
+
 import org.apache.commons.net.ftp.FTPClient;
 import org.apache.commons.net.ftp.FTPSClient;
 import org.slf4j.Logger;
@@ -27,26 +29,15 @@ import org.slf4j.LoggerFactory;
  * FtpsWagon
  *
  *
- * @plexus.component role="org.apache.maven.wagon.Wagon"
- * role-hint="ftps"
- * instantiation-strategy="per-lookup"
  */
+@Named("ftps")
 public class FtpsWagon extends FtpWagon {
     private static final Logger LOG = LoggerFactory.getLogger(FtpsWagon.class);
 
-    /**
-     * @plexus.configuration default-value="TLS"
-     */
     private String securityProtocol = "TLS";
 
-    /**
-     * @plexus.configuration default-value="false"
-     */
     private boolean implicit = false;
 
-    /**
-     * @plexus.configuration default-value="true"
-     */
     private boolean endpointChecking = true;
 
     @Override

--- a/wagon-providers/wagon-http-lightweight/pom.xml
+++ b/wagon-providers/wagon-http-lightweight/pom.xml
@@ -23,7 +23,7 @@ under the License.
   <parent>
     <groupId>org.apache.maven.wagon</groupId>
     <artifactId>wagon-providers</artifactId>
-    <version>3.5.4-SNAPSHOT</version>
+    <version>3.6.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>wagon-http-lightweight</artifactId>

--- a/wagon-providers/wagon-http-lightweight/pom.xml
+++ b/wagon-providers/wagon-http-lightweight/pom.xml
@@ -68,13 +68,4 @@ under the License.
       <scope>test</scope>
     </dependency>
   </dependencies>
-
-  <build>
-    <plugins>
-      <plugin>
-        <groupId>org.codehaus.plexus</groupId>
-        <artifactId>plexus-component-metadata</artifactId>
-      </plugin>
-    </plugins>
-  </build>
 </project>

--- a/wagon-providers/wagon-http-lightweight/src/main/java/org/apache/maven/wagon/providers/http/LightweightHttpWagon.java
+++ b/wagon-providers/wagon-http-lightweight/src/main/java/org/apache/maven/wagon/providers/http/LightweightHttpWagon.java
@@ -18,6 +18,9 @@
  */
 package org.apache.maven.wagon.providers.http;
 
+import javax.inject.Inject;
+import javax.inject.Named;
+
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
@@ -62,9 +65,9 @@ import static org.apache.maven.wagon.shared.http.HttpMessageUtils.formatTransfer
  * LightweightHttpWagon, using JDK's HttpURLConnection.
  *
  * @author <a href="michal.maczka@dimatics.com">Michal Maczka</a>
- * @plexus.component role="org.apache.maven.wagon.Wagon" role-hint="http" instantiation-strategy="per-lookup"
  * @see HttpURLConnection
  */
+@Named("http")
 public class LightweightHttpWagon extends StreamWagon {
     private boolean preemptiveAuthentication;
 
@@ -80,18 +83,12 @@ public class LightweightHttpWagon extends StreamWagon {
     /**
      * Whether to use any proxy cache or not.
      *
-     * @plexus.configuration default="false"
      */
     private boolean useCache;
 
-    /**
-     * @plexus.configuration
-     */
     private Properties httpHeaders;
 
-    /**
-     * @plexus.requirement
-     */
+    @Inject
     private volatile LightweightHttpWagonAuthenticator authenticator;
 
     /**

--- a/wagon-providers/wagon-http-lightweight/src/main/java/org/apache/maven/wagon/providers/http/LightweightHttpWagonAuthenticator.java
+++ b/wagon-providers/wagon-http-lightweight/src/main/java/org/apache/maven/wagon/providers/http/LightweightHttpWagonAuthenticator.java
@@ -18,13 +18,17 @@
  */
 package org.apache.maven.wagon.providers.http;
 
+import javax.inject.Named;
+import javax.inject.Singleton;
+
 import java.net.Authenticator;
 import java.net.PasswordAuthentication;
 
 /**
  * @author <a href="mailto:nicolas.deloof@cloudbees.com">Nicolas De loof</a>
- * @plexus.component role="org.apache.maven.wagon.providers.http.LightweightHttpWagonAuthenticator"
  */
+@Named
+@Singleton
 public class LightweightHttpWagonAuthenticator extends Authenticator {
     ThreadLocal<LightweightHttpWagon> localWagon = new ThreadLocal<>();
 

--- a/wagon-providers/wagon-http-lightweight/src/main/java/org/apache/maven/wagon/providers/http/LightweightHttpsWagon.java
+++ b/wagon-providers/wagon-http-lightweight/src/main/java/org/apache/maven/wagon/providers/http/LightweightHttpsWagon.java
@@ -18,6 +18,8 @@
  */
 package org.apache.maven.wagon.providers.http;
 
+import javax.inject.Named;
+
 import org.apache.maven.wagon.ConnectionException;
 import org.apache.maven.wagon.authentication.AuthenticationException;
 import org.apache.maven.wagon.proxy.ProxyInfo;
@@ -28,10 +30,8 @@ import org.apache.maven.wagon.proxy.ProxyInfo;
  * @author <a href="mailto:joakim@erdfelt.com">Joakim Erdfelt</a>
  *
  *
- * @plexus.component role="org.apache.maven.wagon.Wagon"
- *   role-hint="https"
- *   instantiation-strategy="per-lookup"
  */
+@Named("https")
 public class LightweightHttpsWagon extends LightweightHttpWagon {
     private String previousHttpsProxyHost;
 

--- a/wagon-providers/wagon-http-shared/pom.xml
+++ b/wagon-providers/wagon-http-shared/pom.xml
@@ -23,7 +23,7 @@ under the License.
   <parent>
     <groupId>org.apache.maven.wagon</groupId>
     <artifactId>wagon-providers</artifactId>
-    <version>3.5.4-SNAPSHOT</version>
+    <version>3.6.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>wagon-http-shared</artifactId>

--- a/wagon-providers/wagon-http-shared/src/main/java/org/apache/maven/wagon/shared/http/AbstractHttpClientWagon.java
+++ b/wagon-providers/wagon-http-shared/src/main/java/org/apache/maven/wagon/shared/http/AbstractHttpClientWagon.java
@@ -516,7 +516,6 @@ public abstract class AbstractHttpClientWagon extends StreamWagon {
     private Closeable closeable;
 
     /**
-     * @plexus.configuration
      * @deprecated Use httpConfiguration instead.
      */
     private Properties httpHeaders;

--- a/wagon-providers/wagon-http/pom.xml
+++ b/wagon-providers/wagon-http/pom.xml
@@ -23,7 +23,7 @@ under the License.
   <parent>
     <groupId>org.apache.maven.wagon</groupId>
     <artifactId>wagon-providers</artifactId>
-    <version>3.5.4-SNAPSHOT</version>
+    <version>3.6.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>wagon-http</artifactId>

--- a/wagon-providers/wagon-http/pom.xml
+++ b/wagon-providers/wagon-http/pom.xml
@@ -109,10 +109,6 @@ under the License.
   <build>
     <plugins>
       <plugin>
-        <groupId>org.codehaus.plexus</groupId>
-        <artifactId>plexus-component-metadata</artifactId>
-      </plugin>
-      <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-shade-plugin</artifactId>
         <executions>

--- a/wagon-providers/wagon-scm/pom.xml
+++ b/wagon-providers/wagon-scm/pom.xml
@@ -94,10 +94,6 @@ under the License.
   <build>
     <plugins>
       <plugin>
-        <groupId>org.codehaus.plexus</groupId>
-        <artifactId>plexus-component-metadata</artifactId>
-      </plugin>
-      <plugin>
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
           <excludes />

--- a/wagon-providers/wagon-scm/pom.xml
+++ b/wagon-providers/wagon-scm/pom.xml
@@ -23,7 +23,7 @@ under the License.
   <parent>
     <groupId>org.apache.maven.wagon</groupId>
     <artifactId>wagon-providers</artifactId>
-    <version>3.5.4-SNAPSHOT</version>
+    <version>3.6.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>wagon-scm</artifactId>

--- a/wagon-providers/wagon-scm/src/main/java/org/apache/maven/wagon/providers/scm/ScmWagon.java
+++ b/wagon-providers/wagon-scm/src/main/java/org/apache/maven/wagon/providers/scm/ScmWagon.java
@@ -18,6 +18,9 @@
  */
 package org.apache.maven.wagon.providers.scm;
 
+import javax.inject.Inject;
+import javax.inject.Named;
+
 import java.io.File;
 import java.io.IOException;
 import java.text.DecimalFormat;
@@ -70,12 +73,10 @@ import org.codehaus.plexus.util.StringUtils;
  * @author <a href="carlos@apache.org">Carlos Sanchez</a>
  * @author Jason van Zyl
  *
- * @plexus.component role="org.apache.maven.wagon.Wagon" role-hint="scm" instantiation-strategy="per-lookup"
  */
+@Named("scm")
 public class ScmWagon extends AbstractWagon {
-    /**
-     * @plexus.requirement
-     */
+    @Inject
     private volatile ScmManager scmManager;
 
     /**

--- a/wagon-providers/wagon-scm/src/test/java/org/apache/maven/wagon/providers/scm/UserSafeGitExeScmProvider.java
+++ b/wagon-providers/wagon-scm/src/test/java/org/apache/maven/wagon/providers/scm/UserSafeGitExeScmProvider.java
@@ -26,9 +26,6 @@ import org.apache.maven.scm.provider.git.GitScmTestUtils;
 import org.apache.maven.scm.provider.git.gitexe.GitExeScmProvider;
 import org.apache.maven.scm.repository.ScmRepository;
 
-/**
- * @plexus.component role="org.apache.maven.scm.provider.ScmProvider" role-hint="git"
- */
 public class UserSafeGitExeScmProvider extends GitExeScmProvider {
 
     @Override

--- a/wagon-providers/wagon-ssh-common-test/pom.xml
+++ b/wagon-providers/wagon-ssh-common-test/pom.xml
@@ -23,7 +23,7 @@ under the License.
   <parent>
     <groupId>org.apache.maven.wagon</groupId>
     <artifactId>wagon-providers</artifactId>
-    <version>3.5.4-SNAPSHOT</version>
+    <version>3.6.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>wagon-ssh-common-test</artifactId>

--- a/wagon-providers/wagon-ssh-common-test/src/main/java/org/apache/maven/wagon/providers/ssh/knownhost/KnownHostsProviderTestCase.java
+++ b/wagon-providers/wagon-ssh-common-test/src/main/java/org/apache/maven/wagon/providers/ssh/knownhost/KnownHostsProviderTestCase.java
@@ -22,12 +22,20 @@ import org.apache.maven.wagon.Wagon;
 import org.apache.maven.wagon.providers.ssh.SshWagon;
 import org.apache.maven.wagon.providers.ssh.TestData;
 import org.apache.maven.wagon.repository.Repository;
+import org.codehaus.plexus.ContainerConfiguration;
+import org.codehaus.plexus.PlexusConstants;
 import org.codehaus.plexus.PlexusTestCase;
 
 /**
  *
  */
 public class KnownHostsProviderTestCase extends PlexusTestCase {
+    @Override
+    protected void customizeContainerConfiguration(ContainerConfiguration configuration) {
+        // the providers are @Named beans now, so the container has to read META-INF/sisu
+        configuration.setClassPathScanning(PlexusConstants.SCANNING_INDEX);
+    }
+
     protected KnownHostsProvider okHostsProvider;
 
     protected KnownHostsProvider failHostsProvider;

--- a/wagon-providers/wagon-ssh-common/pom.xml
+++ b/wagon-providers/wagon-ssh-common/pom.xml
@@ -44,13 +44,4 @@ under the License.
       <scope>test</scope>
     </dependency>
   </dependencies>
-
-  <build>
-    <plugins>
-      <plugin>
-        <groupId>org.codehaus.plexus</groupId>
-        <artifactId>plexus-component-metadata</artifactId>
-      </plugin>
-    </plugins>
-  </build>
 </project>

--- a/wagon-providers/wagon-ssh-common/pom.xml
+++ b/wagon-providers/wagon-ssh-common/pom.xml
@@ -23,7 +23,7 @@ under the License.
   <parent>
     <groupId>org.apache.maven.wagon</groupId>
     <artifactId>wagon-providers</artifactId>
-    <version>3.5.4-SNAPSHOT</version>
+    <version>3.6.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>wagon-ssh-common</artifactId>

--- a/wagon-providers/wagon-ssh-common/src/main/java/org/apache/maven/wagon/providers/ssh/interactive/ConsoleInteractiveUserInfo.java
+++ b/wagon-providers/wagon-ssh-common/src/main/java/org/apache/maven/wagon/providers/ssh/interactive/ConsoleInteractiveUserInfo.java
@@ -18,6 +18,9 @@
  */
 package org.apache.maven.wagon.providers.ssh.interactive;
 
+import javax.inject.Inject;
+import javax.inject.Named;
+
 import java.util.Arrays;
 
 import org.codehaus.plexus.components.interactivity.Prompter;
@@ -29,13 +32,11 @@ import org.codehaus.plexus.components.interactivity.PrompterException;
  * @author Juan F. Codagnone
  * @since Sep 12, 2005
  *
- * @plexus.component role="org.apache.maven.wagon.providers.ssh.interactive.InteractiveUserInfo"
- *    instantiation-strategy="per-lookup"
  */
+@Named
 public class ConsoleInteractiveUserInfo implements InteractiveUserInfo {
-    /**
-     * @plexus.requirement role-hint="default"
-     */
+    @Inject
+    @Named("default")
     private volatile Prompter prompter;
 
     public ConsoleInteractiveUserInfo() {}

--- a/wagon-providers/wagon-ssh-common/src/main/java/org/apache/maven/wagon/providers/ssh/knownhost/AbstractKnownHostsProvider.java
+++ b/wagon-providers/wagon-ssh-common/src/main/java/org/apache/maven/wagon/providers/ssh/knownhost/AbstractKnownHostsProvider.java
@@ -32,7 +32,6 @@ public abstract class AbstractKnownHostsProvider implements KnownHostsProvider {
     /**
      * Valid values are ask, yes, no.
      *
-     * @plexus.configuration default-value="ask"
      */
     private String hostKeyChecking = "ask";
 

--- a/wagon-providers/wagon-ssh-common/src/main/java/org/apache/maven/wagon/providers/ssh/knownhost/FileKnownHostsProvider.java
+++ b/wagon-providers/wagon-ssh-common/src/main/java/org/apache/maven/wagon/providers/ssh/knownhost/FileKnownHostsProvider.java
@@ -18,6 +18,8 @@
  */
 package org.apache.maven.wagon.providers.ssh.knownhost;
 
+import javax.inject.Named;
+
 import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.FileInputStream;
@@ -33,10 +35,8 @@ import org.codehaus.plexus.util.FileUtils;
  * @author Juan F. Codagnone
  * @since Sep 12, 2005
  *
- * @plexus.component role="org.apache.maven.wagon.providers.ssh.knownhost.KnownHostsProvider"
- *    role-hint="file"
- *    instantiation-strategy="per-lookup"
  */
+@Named("file")
 public class FileKnownHostsProvider extends StreamKnownHostsProvider {
     private final File file;
 

--- a/wagon-providers/wagon-ssh-common/src/main/java/org/apache/maven/wagon/providers/ssh/knownhost/NullKnownHostProvider.java
+++ b/wagon-providers/wagon-ssh-common/src/main/java/org/apache/maven/wagon/providers/ssh/knownhost/NullKnownHostProvider.java
@@ -18,14 +18,14 @@
  */
 package org.apache.maven.wagon.providers.ssh.knownhost;
 
+import javax.inject.Named;
+
 /**
  * Dummy <code>KnownHostsProvider</code>
  *
  * @author Juan F. Codagnone
  * @since Sep 12, 2005
  *
- * @plexus.component role="org.apache.maven.wagon.providers.ssh.knownhost.KnownHostsProvider"
- *    role-hint="null"
- *    instantiation-strategy="per-lookup"
  */
+@Named("null")
 public final class NullKnownHostProvider extends AbstractKnownHostsProvider {}

--- a/wagon-providers/wagon-ssh-common/src/main/java/org/apache/maven/wagon/providers/ssh/knownhost/SingleKnownHostProvider.java
+++ b/wagon-providers/wagon-ssh-common/src/main/java/org/apache/maven/wagon/providers/ssh/knownhost/SingleKnownHostProvider.java
@@ -18,16 +18,16 @@
  */
 package org.apache.maven.wagon.providers.ssh.knownhost;
 
+import javax.inject.Named;
+
 /**
  * Simple <code>KnownHostsProvider</code> with known wired values
  *
- * @plexus.component role="org.apache.maven.wagon.providers.ssh.knownhost.KnownHostsProvider"
- *    role-hint="single"
- *    instantiation-strategy="per-lookup"
  *
  * @author Juan F. Codagnone
  * @since Sep 12, 2005
  */
+@Named("single")
 public class SingleKnownHostProvider extends AbstractKnownHostsProvider {
     public SingleKnownHostProvider() {}
 

--- a/wagon-providers/wagon-ssh-external/pom.xml
+++ b/wagon-providers/wagon-ssh-external/pom.xml
@@ -60,15 +60,6 @@ under the License.
     </dependency>
   </dependencies>
 
-  <build>
-    <plugins>
-      <plugin>
-        <groupId>org.codehaus.plexus</groupId>
-        <artifactId>plexus-component-metadata</artifactId>
-      </plugin>
-    </plugins>
-  </build>
-
   <profiles>
     <profile>
       <id>no-ssh-tests</id>

--- a/wagon-providers/wagon-ssh-external/pom.xml
+++ b/wagon-providers/wagon-ssh-external/pom.xml
@@ -23,7 +23,7 @@ under the License.
   <parent>
     <groupId>org.apache.maven.wagon</groupId>
     <artifactId>wagon-providers</artifactId>
-    <version>3.5.4-SNAPSHOT</version>
+    <version>3.6.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>wagon-ssh-external</artifactId>

--- a/wagon-providers/wagon-ssh-external/src/main/java/org/apache/maven/wagon/providers/ssh/external/ScpExternalCommandExecutor.java
+++ b/wagon-providers/wagon-ssh-external/src/main/java/org/apache/maven/wagon/providers/ssh/external/ScpExternalCommandExecutor.java
@@ -18,6 +18,11 @@
  */
 package org.apache.maven.wagon.providers.ssh.external;
 
+import javax.inject.Named;
+
+import org.apache.maven.wagon.CommandExecutor;
+import org.eclipse.sisu.Typed;
+
 /**
  * ScpExternalCommandExecutor - bridge class for plexus:descriptor
  *
@@ -26,10 +31,9 @@ package org.apache.maven.wagon.providers.ssh.external;
  *
  * @todo is this even needed anymore?
  *
- * @plexus.component role="org.apache.maven.wagon.CommandExecutor"
- *   role-hint="scpexe"
- *   instantiation-strategy="per-lookup"
  */
+@Named("scpexe")
+@Typed(CommandExecutor.class)
 public class ScpExternalCommandExecutor extends ScpExternalWagon {
 
     public ScpExternalCommandExecutor() {

--- a/wagon-providers/wagon-ssh-external/src/main/java/org/apache/maven/wagon/providers/ssh/external/ScpExternalWagon.java
+++ b/wagon-providers/wagon-ssh-external/src/main/java/org/apache/maven/wagon/providers/ssh/external/ScpExternalWagon.java
@@ -18,6 +18,8 @@
  */
 package org.apache.maven.wagon.providers.ssh.external;
 
+import javax.inject.Named;
+
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.util.List;
@@ -31,6 +33,7 @@ import org.apache.maven.wagon.PermissionModeUtils;
 import org.apache.maven.wagon.ResourceDoesNotExistException;
 import org.apache.maven.wagon.Streams;
 import org.apache.maven.wagon.TransferFailedException;
+import org.apache.maven.wagon.Wagon;
 import org.apache.maven.wagon.WagonConstants;
 import org.apache.maven.wagon.authentication.AuthenticationException;
 import org.apache.maven.wagon.authentication.AuthenticationInfo;
@@ -43,6 +46,7 @@ import org.codehaus.plexus.util.StringUtils;
 import org.codehaus.plexus.util.cli.CommandLineException;
 import org.codehaus.plexus.util.cli.CommandLineUtils;
 import org.codehaus.plexus.util.cli.Commandline;
+import org.eclipse.sisu.Typed;
 
 /**
  * SCP deployer using "external" scp program.  To allow for
@@ -50,10 +54,9 @@ import org.codehaus.plexus.util.cli.Commandline;
  *
  * @author <a href="mailto:brett@apache.org">Brett Porter</a>
  * @todo [BP] add compression flag
- * @plexus.component role="org.apache.maven.wagon.Wagon"
- * role-hint="scpexe"
- * instantiation-strategy="per-lookup"
  */
+@Named("scpexe")
+@Typed(Wagon.class)
 public class ScpExternalWagon extends AbstractWagon implements CommandExecutor {
     /**
      * The external SCP command to use - default is <code>scp</code>.

--- a/wagon-providers/wagon-ssh/pom.xml
+++ b/wagon-providers/wagon-ssh/pom.xml
@@ -99,15 +99,6 @@ under the License.
     </dependency>
   </dependencies>
 
-  <build>
-    <plugins>
-      <plugin>
-        <groupId>org.codehaus.plexus</groupId>
-        <artifactId>plexus-component-metadata</artifactId>
-      </plugin>
-    </plugins>
-  </build>
-
   <profiles>
     <profile>
       <id>no-ssh-tests</id>

--- a/wagon-providers/wagon-ssh/pom.xml
+++ b/wagon-providers/wagon-ssh/pom.xml
@@ -23,7 +23,7 @@ under the License.
   <parent>
     <groupId>org.apache.maven.wagon</groupId>
     <artifactId>wagon-providers</artifactId>
-    <version>3.5.4-SNAPSHOT</version>
+    <version>3.6.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>wagon-ssh</artifactId>

--- a/wagon-providers/wagon-ssh/src/main/java/org/apache/maven/wagon/providers/ssh/jsch/AbstractJschWagon.java
+++ b/wagon-providers/wagon-ssh/src/main/java/org/apache/maven/wagon/providers/ssh/jsch/AbstractJschWagon.java
@@ -18,6 +18,9 @@
  */
 package org.apache.maven.wagon.providers.ssh.jsch;
 
+import javax.inject.Inject;
+import javax.inject.Named;
+
 import java.io.BufferedReader;
 import java.io.ByteArrayInputStream;
 import java.io.File;
@@ -80,24 +83,16 @@ public abstract class AbstractJschWagon extends StreamWagon implements SshWagon,
 
     private String strictHostKeyChecking;
 
-    /**
-     * @plexus.requirement role-hint="file"
-     */
+    @Inject
+    @Named("file")
     private volatile KnownHostsProvider knownHostsProvider;
 
-    /**
-     * @plexus.requirement
-     */
+    @Inject
     private volatile InteractiveUserInfo interactiveUserInfo;
 
-    /**
-     * @plexus.configuration
-     */
     private volatile String preferredAuthentications;
 
-    /**
-     * @plexus.requirement
-     */
+    @Inject
     private volatile UIKeyboardInteractive uIKeyboardInteractive;
 
     private static final int SOCKS5_PROXY_PORT = 1080;

--- a/wagon-providers/wagon-ssh/src/main/java/org/apache/maven/wagon/providers/ssh/jsch/ScpCommandExecutor.java
+++ b/wagon-providers/wagon-ssh/src/main/java/org/apache/maven/wagon/providers/ssh/jsch/ScpCommandExecutor.java
@@ -18,6 +18,11 @@
  */
 package org.apache.maven.wagon.providers.ssh.jsch;
 
+import javax.inject.Named;
+
+import org.apache.maven.wagon.CommandExecutor;
+import org.eclipse.sisu.Typed;
+
 /**
  * ScpCommandExecutor - bridge class for plexus:descriptor
  *
@@ -26,10 +31,9 @@ package org.apache.maven.wagon.providers.ssh.jsch;
  *
  * @todo is this even needed anymore?
  *
- * @plexus.component role="org.apache.maven.wagon.CommandExecutor"
- *   role-hint="scp"
- *   instantiation-strategy="per-lookup"
  */
+@Named("scp")
+@Typed(CommandExecutor.class)
 public class ScpCommandExecutor extends ScpWagon {
     public ScpCommandExecutor() {
         super();

--- a/wagon-providers/wagon-ssh/src/main/java/org/apache/maven/wagon/providers/ssh/jsch/ScpWagon.java
+++ b/wagon-providers/wagon-ssh/src/main/java/org/apache/maven/wagon/providers/ssh/jsch/ScpWagon.java
@@ -18,6 +18,8 @@
  */
 package org.apache.maven.wagon.providers.ssh.jsch;
 
+import javax.inject.Named;
+
 import java.io.EOFException;
 import java.io.IOException;
 import java.io.InputStream;
@@ -31,10 +33,12 @@ import org.apache.maven.wagon.InputData;
 import org.apache.maven.wagon.OutputData;
 import org.apache.maven.wagon.ResourceDoesNotExistException;
 import org.apache.maven.wagon.TransferFailedException;
+import org.apache.maven.wagon.Wagon;
 import org.apache.maven.wagon.events.TransferEvent;
 import org.apache.maven.wagon.providers.ssh.ScpHelper;
 import org.apache.maven.wagon.repository.RepositoryPermissions;
 import org.apache.maven.wagon.resource.Resource;
+import org.eclipse.sisu.Typed;
 
 /**
  * SCP protocol wagon.
@@ -48,10 +52,9 @@ import org.apache.maven.wagon.resource.Resource;
  *
  *
  * @todo [BP] add compression flag
- * @plexus.component role="org.apache.maven.wagon.Wagon"
- * role-hint="scp"
- * instantiation-strategy="per-lookup"
  */
+@Named("scp")
+@Typed(Wagon.class)
 public class ScpWagon extends AbstractJschWagon {
     private static final char COPY_START_CHAR = 'C';
 

--- a/wagon-providers/wagon-ssh/src/main/java/org/apache/maven/wagon/providers/ssh/jsch/SftpWagon.java
+++ b/wagon-providers/wagon-ssh/src/main/java/org/apache/maven/wagon/providers/ssh/jsch/SftpWagon.java
@@ -18,6 +18,8 @@
  */
 package org.apache.maven.wagon.providers.ssh.jsch;
 
+import javax.inject.Named;
+
 import java.io.File;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -33,12 +35,14 @@ import org.apache.maven.wagon.OutputData;
 import org.apache.maven.wagon.PathUtils;
 import org.apache.maven.wagon.ResourceDoesNotExistException;
 import org.apache.maven.wagon.TransferFailedException;
+import org.apache.maven.wagon.Wagon;
 import org.apache.maven.wagon.authentication.AuthenticationException;
 import org.apache.maven.wagon.authorization.AuthorizationException;
 import org.apache.maven.wagon.events.TransferEvent;
 import org.apache.maven.wagon.providers.ssh.ScpHelper;
 import org.apache.maven.wagon.repository.RepositoryPermissions;
 import org.apache.maven.wagon.resource.Resource;
+import org.eclipse.sisu.Typed;
 
 /**
  * SFTP protocol wagon.
@@ -48,10 +52,9 @@ import org.apache.maven.wagon.resource.Resource;
  * @todo [BP] add compression flag
  * @todo see if SftpProgressMonitor allows us to do streaming (without it, we can't do checksums as the input stream is lost)
  *
- * @plexus.component role="org.apache.maven.wagon.Wagon"
- *   role-hint="sftp"
- *   instantiation-strategy="per-lookup"
  */
+@Named("sftp")
+@Typed(Wagon.class)
 public class SftpWagon extends AbstractJschWagon {
     private static final String SFTP_CHANNEL = "sftp";
 

--- a/wagon-providers/wagon-ssh/src/main/java/org/apache/maven/wagon/providers/ssh/jsch/interactive/PrompterUIKeyboardInteractive.java
+++ b/wagon-providers/wagon-ssh/src/main/java/org/apache/maven/wagon/providers/ssh/jsch/interactive/PrompterUIKeyboardInteractive.java
@@ -18,6 +18,10 @@
  */
 package org.apache.maven.wagon.providers.ssh.jsch.interactive;
 
+import javax.inject.Inject;
+import javax.inject.Named;
+import javax.inject.Singleton;
+
 import com.jcraft.jsch.UIKeyboardInteractive;
 import org.codehaus.plexus.components.interactivity.Prompter;
 import org.codehaus.plexus.components.interactivity.PrompterException;
@@ -32,12 +36,12 @@ import org.codehaus.plexus.components.interactivity.PrompterException;
  * @author <a href="mailto:juam at users.sourceforge.net">Juan F. Codagnone</a>
  * @since Sep 22, 2005
  *
- * @plexus.component role="com.jcraft.jsch.UIKeyboardInteractive"
  */
+@Named
+@Singleton
 public class PrompterUIKeyboardInteractive implements UIKeyboardInteractive {
-    /**
-     * @plexus.requirement role-hint="default"
-     */
+    @Inject
+    @Named("default")
     private volatile Prompter prompter;
 
     public PrompterUIKeyboardInteractive() {}

--- a/wagon-providers/wagon-ssh/src/test/java/org/apache/maven/wagon/providers/ssh/jsch/ScpWagonWithProxyTest.java
+++ b/wagon-providers/wagon-ssh/src/test/java/org/apache/maven/wagon/providers/ssh/jsch/ScpWagonWithProxyTest.java
@@ -32,6 +32,8 @@ import org.apache.maven.wagon.Wagon;
 import org.apache.maven.wagon.authentication.AuthenticationException;
 import org.apache.maven.wagon.proxy.ProxyInfo;
 import org.apache.maven.wagon.repository.Repository;
+import org.codehaus.plexus.ContainerConfiguration;
+import org.codehaus.plexus.PlexusConstants;
 import org.codehaus.plexus.PlexusTestCase;
 import org.eclipse.jetty.server.Handler;
 import org.eclipse.jetty.server.HttpConfiguration;
@@ -42,6 +44,12 @@ import org.eclipse.jetty.server.ServerConnector;
 import org.eclipse.jetty.server.handler.AbstractHandler;
 
 public class ScpWagonWithProxyTest extends PlexusTestCase {
+    @Override
+    protected void customizeContainerConfiguration(ContainerConfiguration configuration) {
+        // the providers are @Named beans now, so the container has to read META-INF/sisu
+        configuration.setClassPathScanning(PlexusConstants.SCANNING_INDEX);
+    }
+
     private boolean handled;
 
     public void testHttpProxy() throws Exception {

--- a/wagon-providers/wagon-webdav-jackrabbit/pom.xml
+++ b/wagon-providers/wagon-webdav-jackrabbit/pom.xml
@@ -107,10 +107,6 @@ under the License.
   <build>
     <plugins>
       <plugin>
-        <groupId>org.codehaus.plexus</groupId>
-        <artifactId>plexus-component-metadata</artifactId>
-      </plugin>
-      <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>

--- a/wagon-providers/wagon-webdav-jackrabbit/pom.xml
+++ b/wagon-providers/wagon-webdav-jackrabbit/pom.xml
@@ -23,7 +23,7 @@ under the License.
   <parent>
     <groupId>org.apache.maven.wagon</groupId>
     <artifactId>wagon-providers</artifactId>
-    <version>3.5.4-SNAPSHOT</version>
+    <version>3.6.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>wagon-webdav-jackrabbit</artifactId>

--- a/wagon-providers/wagon-webdav-jackrabbit/src/main/java/org/apache/maven/wagon/providers/webdav/WebDavWagon.java
+++ b/wagon-providers/wagon-webdav-jackrabbit/src/main/java/org/apache/maven/wagon/providers/webdav/WebDavWagon.java
@@ -53,9 +53,6 @@ import static org.apache.maven.wagon.shared.http.HttpMessageUtils.formatResource
  * @author <a href="mailto:joakime@apache.org">Joakim Erdfelt</a>
  * @author <a href="mailto:carlos@apache.org">Carlos Sanchez</a>
  * @author <a href="mailto:james@atlassian.com">James William Dumay</a>
- * @plexus.component role="org.apache.maven.wagon.Wagon"
- * role-hint="dav"
- * instantiation-strategy="per-lookup"
  */
 public class WebDavWagon extends AbstractHttpClientWagon {
     protected static final String CONTINUE_ON_FAILURE_PROPERTY = "wagon.webdav.continueOnFailure";

--- a/wagon-tcks/pom.xml
+++ b/wagon-tcks/pom.xml
@@ -23,7 +23,7 @@ under the License.
   <parent>
     <groupId>org.apache.maven.wagon</groupId>
     <artifactId>wagon</artifactId>
-    <version>3.5.4-SNAPSHOT</version>
+    <version>3.6.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/wagon-tcks/wagon-tck-http/pom.xml
+++ b/wagon-tcks/wagon-tck-http/pom.xml
@@ -23,7 +23,7 @@ under the License.
   <parent>
     <groupId>org.apache.maven.wagon</groupId>
     <artifactId>wagon-tcks</artifactId>
-    <version>3.5.4-SNAPSHOT</version>
+    <version>3.6.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/wagon-tcks/wagon-tck-http/src/main/java/org/apache/maven/wagon/tck/http/HttpWagonTests.java
+++ b/wagon-tcks/wagon-tck-http/src/main/java/org/apache/maven/wagon/tck/http/HttpWagonTests.java
@@ -30,7 +30,10 @@ import org.apache.maven.wagon.authentication.AuthenticationInfo;
 import org.apache.maven.wagon.proxy.ProxyInfo;
 import org.apache.maven.wagon.repository.Repository;
 import org.apache.maven.wagon.tck.http.fixture.ServerFixture;
+import org.codehaus.plexus.ContainerConfiguration;
+import org.codehaus.plexus.DefaultContainerConfiguration;
 import org.codehaus.plexus.DefaultPlexusContainer;
+import org.codehaus.plexus.PlexusConstants;
 import org.codehaus.plexus.PlexusContainer;
 import org.codehaus.plexus.component.configurator.ComponentConfigurationException;
 import org.codehaus.plexus.component.repository.exception.ComponentLifecycleException;
@@ -85,9 +88,11 @@ public abstract class HttpWagonTests {
         System.setProperty("javax.net.ssl.trustStore", keystore.getAbsolutePath());
         System.setProperty("javax.net.ssl.trustStorePassword", ServerFixture.SERVER_SSL_KEYSTORE_PASSWORD);
 
-        container = new DefaultPlexusContainer();
-        // container.initialize();
-        // container.start();
+        ContainerConfiguration config = new DefaultContainerConfiguration();
+        // the providers are @Named beans now, so the container has to read META-INF/sisu
+        config.setClassPathScanning(PlexusConstants.SCANNING_INDEX);
+
+        container = new DefaultPlexusContainer(config);
 
         configurator = (WagonTestCaseConfigurator) container.lookup(WagonTestCaseConfigurator.class.getName());
     }


### PR DESCRIPTION
Backport of #912, which I closed out saying "not for `wagon-3.x`", and #913 repeated that it "belongs to 4.0.0". This PR asks to change that call. The reason it was held back has not gone away — it is set out precisely below — but the cost of keeping 3.x structurally different from master has become the larger of the two.

### Why revisit it

`plexus-component-metadata` and the javadoc-tag dialect it reads are now used nowhere else in the estate; this branch is the last consumer, and the generator is a build-time dependency on a toolchain nobody maintains. Meanwhile every fix that lands on master and needs to come back here now conflicts in the component declarations — this backport itself is the cheap case, at three conflicts, because it *is* the divergence. Later ones pay for it repeatedly.

### The break, precisely

Seven provider jars stop shipping a generated `components.xml` and ship `META-INF/sisu/javax.inject.Named` instead. Between them that is the `file`, `ftp`/`ftps`/`ftph`, lightweight `http`/`https`, `scm`, `scp`/`sftp` and `scpexe` wagons, plus the known-hosts providers, the interactive user info and the two command executors. `wagon-http` (`http`, `https`) and `wagon-webdav-jackrabbit` (`dav`, `davs`, `dav+http`, `dav+https`) map one implementation onto several hints, so they keep their handwritten descriptors and are unaffected.

`new DefaultPlexusContainer()` leaves `classPathScanning` at `off`. An embedder doing that reads descriptors only, and silently stops finding everything in the first list. Maven is not affected: `PlexusWagonProvider` does `lookup(Wagon.class, hint)` and Maven configures its container with index scanning.

Two ways to price that in. Release the result as **3.6.0** rather than 3.5.4 with a release note — nothing has shipped off this line since 3.5.3, so the bump costs nothing and puts the change behind a minor. Or, if a maintenance line should not break embedders at all, hand-write descriptors for all nine providers: the annotations still replace the javadoc tags and the published metadata stays as it is today. I have taken the first: the second commit bumps the branch to `3.6.0-SNAPSHOT`. The fallback is still there if the vote goes the other way.

### The port itself

Cherry-pick of 4af0905a. Twenty-six of the twenty-eight Java files came across identical to master; the two that differ (`WagonTestCase`, `HttpWagonTests`) differ only where 3.x already differed, and their container setup matches master exactly. The one structural difference: this line declared `plexus-component-metadata` in each provider POM rather than in the root, so it is removed from all ten of them and `sisu-maven-plugin` takes its place in the root build.

The reasoning behind the non-mechanical parts — `@Singleton` on the two components Plexus scoped as singletons, `@Typed` on the five that Sisu would otherwise publish under extra roles, and the dropped `@plexus.configuration` defaults — is unchanged from #912 and repeated in the commit message.

Verified: the (role, hint, implementation, instantiation-strategy) tuples generated by this branch before the change → identical to the new sisu index, module by module.

Full reactor green, all 17 modules, at both versions. Note that `verify` does not cover the ssh providers — the `no-ssh-tests` profile skips them — so the container-lookup evidence for the jsch and external wagons is the embedded-sshd tests under `-Dssh-tests`, which pass.

*This change was created with AI assistance.*

