### PR TITLE
Migrate the standalone provider tests to JUnit 5

### DIFF
--- a/wagon-providers/wagon-http-shared/pom.xml
+++ b/wagon-providers/wagon-http-shared/pom.xml
@@ -59,8 +59,8 @@ under the License.
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/wagon-providers/wagon-http-shared/src/test/java/org/apache/maven/wagon/shared/http/EncodingUtilTest.java
+++ b/wagon-providers/wagon-http-shared/src/test/java/org/apache/maven/wagon/shared/http/EncodingUtilTest.java
@@ -21,33 +21,40 @@ package org.apache.maven.wagon.shared.http;
 import java.net.MalformedURLException;
 import java.net.URISyntaxException;
 
-import junit.framework.TestCase;
+import org.junit.jupiter.api.Test;
 
-public class EncodingUtilTest extends TestCase {
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class EncodingUtilTest {
+    @Test
     public void testEncodeURLWithTrailingSlash() {
         String encodedURL = EncodingUtil.encodeURLToString("https://host:1234/test", "demo/");
 
         assertEquals("https://host:1234/test/demo/", encodedURL);
     }
 
+    @Test
     public void testEncodeURLWithSpaces() throws URISyntaxException, MalformedURLException {
         String encodedURL = EncodingUtil.encodeURLToString("file://host:1/path with spaces");
 
         assertEquals("file://host:1/path%20with%20spaces", encodedURL);
     }
 
+    @Test
     public void testEncodeURLWithSpacesInPath() throws URISyntaxException, MalformedURLException {
         String encodedURL = EncodingUtil.encodeURLToString("file://host:1", "path with spaces");
 
         assertEquals("file://host:1/path%20with%20spaces", encodedURL);
     }
 
+    @Test
     public void testEncodeURLWithSpacesInBothBaseAndPath() throws URISyntaxException, MalformedURLException {
         String encodedURL = EncodingUtil.encodeURLToString("file://host:1/with%20a", "path with spaces");
 
         assertEquals("file://host:1/with%20a/path%20with%20spaces", encodedURL);
     }
 
+    @Test
     public void testEncodeURLWithSlashes1() throws URISyntaxException, MalformedURLException {
         String encodedURL = EncodingUtil.encodeURLToString("file://host:1/basePath", "a", "b", "c");
 
@@ -58,6 +65,7 @@ public class EncodingUtilTest extends TestCase {
         assertEquals("file://host:1/basePath/a/b/c", encodedURL);
     }
 
+    @Test
     public void testEncodeURLWithSlashes2() throws URISyntaxException, MalformedURLException {
         String encodedURL = EncodingUtil.encodeURLToString("file://host:1/basePath/", "a", "b", "c");
 
@@ -68,36 +76,42 @@ public class EncodingUtilTest extends TestCase {
         assertEquals("file://host:1/basePath/a/b/c", encodedURL);
     }
 
+    @Test
     public void testEncodeURLWithSlashes3() throws URISyntaxException, MalformedURLException {
         String encodedURL = EncodingUtil.encodeURLToString("file://host:1/basePath/", new String[0]);
 
         assertEquals("file://host:1/basePath/", encodedURL);
     }
 
+    @Test
     public void testEncodeURLWithSlashes4() throws URISyntaxException, MalformedURLException {
         String encodedURL = EncodingUtil.encodeURLToString("file://host:1/basePath", new String[0]);
 
         assertEquals("file://host:1/basePath", encodedURL);
     }
 
+    @Test
     public void testEncodeURLWithSlashes5() throws URISyntaxException, MalformedURLException {
         String encodedURL = EncodingUtil.encodeURLToString("file://host:1/basePath", "a/1", "b/1", "c/1");
 
         assertEquals("file://host:1/basePath/a%2F1/b%2F1/c%2F1", encodedURL);
     }
 
+    @Test
     public void testEncodeURLWithSlashes6() throws URISyntaxException, MalformedURLException {
         String encodedURL = EncodingUtil.encodeURLToString("file://host:1/", new String[0]);
 
         assertEquals("file://host:1/", encodedURL);
     }
 
+    @Test
     public void testEncodeURLWithSlashes7() throws URISyntaxException, MalformedURLException {
         String encodedURL = EncodingUtil.encodeURLToString("file://host:1", new String[0]);
 
         assertEquals("file://host:1", encodedURL);
     }
 
+    @Test
     public void testEncodeURLWithNonLatin() throws URISyntaxException, MalformedURLException {
         String encodedURL = EncodingUtil.encodeURLToString("file://host:1", "пипец/");
 

--- a/wagon-providers/wagon-ssh-common/pom.xml
+++ b/wagon-providers/wagon-ssh-common/pom.xml
@@ -39,8 +39,8 @@ under the License.
       <artifactId>plexus-interactivity-api</artifactId>
     </dependency>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/wagon-providers/wagon-ssh-common/src/test/java/org/apache/maven/wagon/providers/ssh/LSParserTest.java
+++ b/wagon-providers/wagon-ssh-common/src/test/java/org/apache/maven/wagon/providers/ssh/LSParserTest.java
@@ -20,10 +20,15 @@ package org.apache.maven.wagon.providers.ssh;
 
 import java.util.List;
 
-import junit.framework.TestCase;
 import org.apache.maven.wagon.TransferFailedException;
+import org.junit.jupiter.api.Test;
 
-public class LSParserTest extends TestCase {
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class LSParserTest {
+    @Test
     public void testParseLinux() throws TransferFailedException {
         String rawLS = "total 32\n" + "drwxr-xr-x  5 joakim joakim 4096 2006-12-11 10:30 .\n"
                 + "drwxr-xr-x 14 joakim joakim 4096 2006-12-11 10:30 ..\n"
@@ -43,6 +48,7 @@ public class LSParserTest extends TestCase {
         assertTrue(files.contains("spaced out"));
     }
 
+    @Test
     public void testParseOSX() throws TransferFailedException {
         String rawLS = "total 32\n" + "drwxr-xr-x   5  joakim  joakim   238 Dec 11 10:30 .\n"
                 + "drwxr-xr-x  14  joakim  joakim   518 Dec 11 10:30 ..\n"
@@ -62,6 +68,7 @@ public class LSParserTest extends TestCase {
         assertTrue(files.contains("spaced out"));
     }
 
+    @Test
     public void testParseOSXFrLocale() throws TransferFailedException {
         String rawLS = "total 40\n" + "-rw-r--r--  1 olamy  staff  11 21 sep 00:34 .index.txt\n"
                 + "-rw-r--r--  1 olamy  staff  19 21 sep 00:34 more-resources.dat\n"
@@ -77,6 +84,7 @@ public class LSParserTest extends TestCase {
         assertTrue(files.contains(".index.txt"));
     }
 
+    @Test
     public void testParseCygwin() throws TransferFailedException {
         String rawLS = "total 32\n" + "drwxr-xr-x+  5 joakim None    0 Dec 11 10:30 .\n"
                 + "drwxr-xr-x+ 14 joakim None    0 Dec 11 10:30 ..\n"
@@ -101,6 +109,7 @@ public class LSParserTest extends TestCase {
      * Just adding a real-world example of the ls to see if it is a problem.
      *   - Joakime
      */
+    @Test
     public void testParsePeopleApacheStaging() throws TransferFailedException {
         String rawLS = "total 6\n"
                 + "drwxr-xr-x  3 snicoll  snicoll  512 Feb  7 11:04 .\n"

--- a/wagon-providers/wagon-ssh-common/src/test/java/org/apache/maven/wagon/providers/ssh/knownhost/FileKnownHostsProviderTest.java
+++ b/wagon-providers/wagon-ssh-common/src/test/java/org/apache/maven/wagon/providers/ssh/knownhost/FileKnownHostsProviderTest.java
@@ -20,16 +20,21 @@ package org.apache.maven.wagon.providers.ssh.knownhost;
 
 import java.io.File;
 
-import junit.framework.TestCase;
 import org.codehaus.plexus.util.FileUtils;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-public class FileKnownHostsProviderTest extends TestCase {
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+public class FileKnownHostsProviderTest {
     private File basedir = new File(System.getProperty("basedir", "."));
 
     private File testKnownHostsFile;
 
     private FileKnownHostsProvider provider;
 
+    @BeforeEach
     public void setUp() throws Exception {
         File readonlyKnownHostFile = new File(basedir, "src/test/resources/known_hosts");
         testKnownHostsFile = new File(basedir, "target/known_hosts");
@@ -40,6 +45,7 @@ public class FileKnownHostsProviderTest extends TestCase {
         provider = new FileKnownHostsProvider(testKnownHostsFile);
     }
 
+    @Test
     public void testStoreKnownHostsNoChange() throws Exception {
         long timestamp = this.testKnownHostsFile.lastModified();
         // file with the same contents, but with entries swapped
@@ -47,9 +53,10 @@ public class FileKnownHostsProviderTest extends TestCase {
         String contents = FileUtils.fileRead(sameKnownHostFile);
 
         provider.storeKnownHosts(contents);
-        assertEquals("known_hosts file is rewritten", timestamp, testKnownHostsFile.lastModified());
+        assertEquals(timestamp, testKnownHostsFile.lastModified(), "known_hosts file is rewritten");
     }
 
+    @Test
     public void testStoreKnownHostsWithChange() throws Exception {
         long timestamp = this.testKnownHostsFile.lastModified();
         File sameKnownHostFile = new File(basedir, "src/test/resources/known_hosts_same");
@@ -57,6 +64,6 @@ public class FileKnownHostsProviderTest extends TestCase {
         contents += "1 2 3";
 
         provider.storeKnownHosts(contents);
-        assertTrue("known_hosts file is not rewritten", timestamp != testKnownHostsFile.lastModified());
+        assertNotEquals(timestamp, testKnownHostsFile.lastModified(), "known_hosts file is not rewritten");
     }
 }

--- a/wagon-providers/wagon-webdav-jackrabbit/pom.xml
+++ b/wagon-providers/wagon-webdav-jackrabbit/pom.xml
@@ -81,6 +81,17 @@ under the License.
 
     <!-- Test dependencies -->
     <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <!-- WebDavWagonTest and its subclasses inherit JUnit 4 tests from the published HttpWagonTestCase -->
+    <dependency>
+      <groupId>org.junit.vintage</groupId>
+      <artifactId>junit-vintage-engine</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <scope>test</scope>

--- a/wagon-providers/wagon-webdav-jackrabbit/src/test/java/org/apache/maven/wagon/providers/webdav/HttpClientWagonTest.java
+++ b/wagon-providers/wagon-webdav-jackrabbit/src/test/java/org/apache/maven/wagon/providers/webdav/HttpClientWagonTest.java
@@ -18,7 +18,6 @@
  */
 package org.apache.maven.wagon.providers.webdav;
 
-import junit.framework.TestCase;
 import org.apache.http.Header;
 import org.apache.http.client.methods.HttpHead;
 import org.apache.http.params.HttpParams;
@@ -31,11 +30,15 @@ import org.apache.maven.wagon.proxy.ProxyInfo;
 import org.apache.maven.wagon.repository.Repository;
 import org.apache.maven.wagon.shared.http.HttpConfiguration;
 import org.apache.maven.wagon.shared.http.HttpMethodConfiguration;
-import org.junit.Ignore;
+import org.junit.jupiter.api.Test;
 
-public class HttpClientWagonTest extends TestCase {
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
-    @Ignore("not sure how to test this")
+public class HttpClientWagonTest {
+
+    @Test
     public void testSetPreemptiveAuthParamViaConfig() {
         HttpMethodConfiguration methodConfig = new HttpMethodConfiguration();
         methodConfig.setUsePreemptive(true);
@@ -51,30 +54,9 @@ public class HttpClientWagonTest extends TestCase {
 
         HttpParams params = method.getParams();
         assertNotNull(params);
-        // assertTrue( params.isParameterTrue( HttpClientParams.PREEMPTIVE_AUTHENTICATION ) );
     }
 
-    //    @Ignore("not sure how to test this")
-    //    public void testSetMaxRedirectsParamViaConfig()
-    //    {
-    //        HttpMethodConfiguration methodConfig = new HttpMethodConfiguration();
-    //        int maxRedirects = 2;
-    //        methodConfig.addParam( HttpClientParams.MAX_REDIRECTS, "%i," + maxRedirects );
-    //
-    //        HttpConfiguration config = new HttpConfiguration();
-    //        config.setAll( methodConfig );
-    //
-    //        TestWagon wagon = new TestWagon();
-    //        wagon.setHttpConfiguration( config );
-    //
-    //        HttpHead method = new HttpHead();
-    //        wagon.setParameters( method );
-    //
-    //        HttpParams params = method.getParams();
-    //        assertNotNull( params );
-    //        assertEquals( maxRedirects, params.getIntParameter( HttpClientParams.MAX_REDIRECTS, -1 ) );
-    //    }
-
+    @Test
     public void testDefaultHeadersUsedByDefault() {
         HttpConfiguration config = new HttpConfiguration();
         config.setAll(new HttpMethodConfiguration());
@@ -99,6 +81,7 @@ public class HttpClientWagonTest extends TestCase {
         assertEquals("no-cache", header.getValue());
     }
 
+    @Test
     public void testTurnOffDefaultHeaders() {
         HttpConfiguration config = new HttpConfiguration();
         config.setAll(new HttpMethodConfiguration().setUseDefaultHeaders(false));
@@ -120,7 +103,7 @@ public class HttpClientWagonTest extends TestCase {
         assertNull(header);
     }
 
-    @Ignore("not sure how to test this")
+    @Test
     public void testNTCredentialsWithUsernameNull() throws AuthenticationException, ConnectionException {
         TestWagon wagon = new TestWagon();
 
@@ -131,12 +114,9 @@ public class HttpClientWagonTest extends TestCase {
 
         assertNull(wagon.getAuthenticationInfo().getUserName());
         assertNull(wagon.getAuthenticationInfo().getPassword());
-
-        // assertFalse( wagon.getHttpClient()..getState().getCredentials( new AuthScope( null, 0 ) ) instanceof
-        // NTCredentials );
     }
 
-    @Ignore("not sure how to test this")
+    @Test
     public void testNTCredentialsNoNTDomain() throws AuthenticationException, ConnectionException {
         TestWagon wagon = new TestWagon();
 
@@ -155,12 +135,9 @@ public class HttpClientWagonTest extends TestCase {
 
         assertEquals(myUsernameNoNTDomain, wagon.getAuthenticationInfo().getUserName());
         assertEquals(myPassword, wagon.getAuthenticationInfo().getPassword());
-
-        // assertFalse( wagon.getClient().getState().getCredentials( new AuthScope( null, 0 ) ) instanceof NTCredentials
-        // );
     }
 
-    @Ignore("not sure how to test this")
+    @Test
     public void testNTCredentialsWithNTDomain() throws AuthenticationException, ConnectionException {
         TestWagon wagon = new TestWagon();
 
@@ -181,14 +158,6 @@ public class HttpClientWagonTest extends TestCase {
 
         assertEquals(myNTDomainAndUser, wagon.getAuthenticationInfo().getUserName());
         assertEquals(myPassword, wagon.getAuthenticationInfo().getPassword());
-
-        //        Credentials credentials = wagon.getClient().getState().getCredentials( new AuthScope( null, 0 ) );
-        //        assertTrue( credentials instanceof NTCredentials );
-        //
-        //        NTCredentials ntCredentials = (NTCredentials) credentials;
-        //        assertEquals( myNTDomain, ntCredentials.getDomain() );
-        //        assertEquals( myUsername, ntCredentials.getUserName() );
-        //        assertEquals( myPassword, ntCredentials.getPassword() );
     }
 
     private static final class TestWagon extends WebDavWagon {

--- a/wagon-providers/wagon-webdav-jackrabbit/src/test/java/org/apache/maven/wagon/providers/webdav/MultiStatusTest.java
+++ b/wagon-providers/wagon-webdav-jackrabbit/src/test/java/org/apache/maven/wagon/providers/webdav/MultiStatusTest.java
@@ -23,12 +23,12 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * Tests for parsing {@code 207 Multi-Status} PROPFIND responses.
@@ -133,7 +133,7 @@ public class MultiStatusTest {
 
         assertEquals(2, responses.size());
         assertEquals("/repo/dir/a", responses.get(0).getHref());
-        assertTrue("the later duplicate wins", responses.get(0).isCollection());
+        assertTrue(responses.get(0).isCollection(), "the later duplicate wins");
         assertEquals("/repo/dir/b", responses.get(1).getHref());
     }
 

--- a/wagon-providers/wagon-webdav-jackrabbit/src/test/java/org/apache/maven/wagon/providers/webdav/PathNavigatorTest.java
+++ b/wagon-providers/wagon-webdav-jackrabbit/src/test/java/org/apache/maven/wagon/providers/webdav/PathNavigatorTest.java
@@ -18,14 +18,19 @@
  */
 package org.apache.maven.wagon.providers.webdav;
 
-import junit.framework.TestCase;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * @author <a href="mailto:james@atlassian.com">James William Dumay</a>
  */
-public class PathNavigatorTest extends TestCase {
+public class PathNavigatorTest {
     private static final String TEST_PATH = "foo/bar/baz";
 
+    @Test
     public void testBackAndForward() {
         PathNavigator navigator = new PathNavigator(TEST_PATH);
 


### PR DESCRIPTION
Backport of `a8cafa27` from master, scoped the same way it was scoped there.

Only tests that do **not** extend the bases published from `wagon-provider-test` move. Those bases —
`WagonTestCase`, `StreamingWagonTestCase`, `HttpWagonTestCase`, `CommandExecutorTestCase` — ship in
`src/main/java`, so external providers extend them and inherit their test methods by the `testXxx()`
naming convention: 14, +6, +39 and 3 respectively. Moving them to `@Test` would leave any consumer
still on JUnit 4 running none of those inherited tests, with no compile error and a green build. They
are still on `PlexusTestCase` on master too, so this branch does not lead master there.

Following master file by file: of the twelve candidates here, master migrated six and left six alone.
This migrates the same six. Four were byte-identical to master's pre-migration state, so master's
reviewed version is taken verbatim; `FileKnownHostsProviderTest` and `webdav/HttpClientWagonTest` had
drifted and were ported, keeping this branch's `FileUtils.fileRead` rather than master's
`Files.readAllBytes`.

`wagon-webdav-jackrabbit` keeps `junit` and gains `junit-vintage-engine` alongside `junit-jupiter`,
matching master: it still has a test inheriting from `HttpWagonTestCase`, and surefire provisions the
jupiter engine but not the vintage one. No versions are needed — `maven-parent` 49 imports `junit-bom`.

One behavioural detail worth a look: `HttpClientWagonTest.testSetPreemptiveAuthParamViaConfig` carried
`@Ignore("not sure how to test this")`, but `@Ignore` does nothing on a `junit.framework.TestCase`
subclass — the surefire report confirms that test ran and passed. It is dropped rather than translated,
because `@Disabled` would have silently stopped running it.

Verified: `mvn test` before and after on all three touched modules — wagon-http-shared 12 → 12,
wagon-ssh-common 7 → 7, wagon-webdav-jackrabbit 295 → 295, zero skipped, zero failures, zero errors
throughout. As a negative control, a deliberately broken assertion in a migrated file produced
`failures="1"` and a non-zero build, confirming the migrated tests are really executed rather than
collected as an empty set.

*This change was created with AI assistance.*