### PR TITLE
Migrate the standalone wagon-http tests to JUnit 5

### DIFF
--- a/wagon-providers/wagon-http/pom.xml
+++ b/wagon-providers/wagon-http/pom.xml
@@ -70,6 +70,17 @@ under the License.
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <!-- HttpWagonTest and its subclasses inherit JUnit 4 tests from the published HttpWagonTestCase -->
+    <dependency>
+      <groupId>org.junit.vintage</groupId>
+      <artifactId>junit-vintage-engine</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <scope>test</scope>

--- a/wagon-providers/wagon-http/src/test/java/org/apache/maven/wagon/providers/http/AbstractHttpClientWagonTest.java
+++ b/wagon-providers/wagon-http/src/test/java/org/apache/maven/wagon/providers/http/AbstractHttpClientWagonTest.java
@@ -37,13 +37,13 @@ import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.DefaultHttpRequestRetryHandler;
 import org.apache.http.impl.execchain.RedirectExec;
 import org.apache.http.impl.execchain.RetryExec;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class AbstractHttpClientWagonTest {
 

--- a/wagon-providers/wagon-http/src/test/java/org/apache/maven/wagon/providers/http/BasicAuthScopeTest.java
+++ b/wagon-providers/wagon-http/src/test/java/org/apache/maven/wagon/providers/http/BasicAuthScopeTest.java
@@ -20,8 +20,9 @@ package org.apache.maven.wagon.providers.http;
 
 import org.apache.http.auth.AuthScope;
 import org.apache.maven.wagon.shared.http.BasicAuthScope;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class BasicAuthScopeTest {
 
@@ -34,9 +35,9 @@ public class BasicAuthScopeTest {
         BasicAuthScope scope = new BasicAuthScope();
 
         AuthScope authScope = scope.getScope("original.host.com", 3456);
-        Assert.assertEquals("original.host.com", authScope.getHost());
-        Assert.assertEquals(3456, authScope.getPort());
-        Assert.assertEquals(AuthScope.ANY_REALM, authScope.getRealm());
+        assertEquals("original.host.com", authScope.getHost());
+        assertEquals(3456, authScope.getPort());
+        assertEquals(AuthScope.ANY_REALM, authScope.getRealm());
     }
 
     /**
@@ -49,9 +50,9 @@ public class BasicAuthScopeTest {
         scope.setPort("1234");
         scope.setRealm("override-realm");
         AuthScope authScope = scope.getScope("original.host.com", 3456);
-        Assert.assertEquals("override.host.com", authScope.getHost());
-        Assert.assertEquals(1234, authScope.getPort());
-        Assert.assertEquals("override-realm", authScope.getRealm());
+        assertEquals("override.host.com", authScope.getHost());
+        assertEquals(1234, authScope.getPort());
+        assertEquals("override-realm", authScope.getRealm());
     }
 
     /**
@@ -64,9 +65,9 @@ public class BasicAuthScopeTest {
         scope.setPort("ANY");
         scope.setRealm("ANY");
         AuthScope authScope = scope.getScope("original.host.com", 3456);
-        Assert.assertEquals(AuthScope.ANY_HOST, authScope.getHost());
-        Assert.assertEquals(AuthScope.ANY_PORT, authScope.getPort());
-        Assert.assertEquals(AuthScope.ANY_REALM, authScope.getRealm());
+        assertEquals(AuthScope.ANY_HOST, authScope.getHost());
+        assertEquals(AuthScope.ANY_PORT, authScope.getPort());
+        assertEquals(AuthScope.ANY_REALM, authScope.getRealm());
     }
 
     /**
@@ -77,9 +78,9 @@ public class BasicAuthScopeTest {
         BasicAuthScope scope = new BasicAuthScope();
         scope.setRealm("override-realm");
         AuthScope authScope = scope.getScope("original.host.com", 3456);
-        Assert.assertEquals("original.host.com", authScope.getHost());
-        Assert.assertEquals(3456, authScope.getPort());
-        Assert.assertEquals("override-realm", authScope.getRealm());
+        assertEquals("original.host.com", authScope.getHost());
+        assertEquals(3456, authScope.getPort());
+        assertEquals("override-realm", authScope.getRealm());
     }
 
     /**
@@ -89,6 +90,6 @@ public class BasicAuthScopeTest {
     public void testGetScopeOriginalPortIsNegativeOne() {
         BasicAuthScope scope = new BasicAuthScope();
         AuthScope authScope = scope.getScope("original.host.com", -1);
-        Assert.assertEquals(AuthScope.ANY_PORT, authScope.getPort());
+        assertEquals(AuthScope.ANY_PORT, authScope.getPort());
     }
 }

--- a/wagon-providers/wagon-http/src/test/java/org/apache/maven/wagon/providers/http/HttpClientWagonTest.java
+++ b/wagon-providers/wagon-http/src/test/java/org/apache/maven/wagon/providers/http/HttpClientWagonTest.java
@@ -18,7 +18,6 @@
  */
 package org.apache.maven.wagon.providers.http;
 
-import junit.framework.TestCase;
 import org.apache.http.Header;
 import org.apache.http.client.config.RequestConfig;
 import org.apache.http.client.methods.HttpHead;
@@ -28,9 +27,15 @@ import org.apache.maven.wagon.shared.http.AbstractHttpClientWagon;
 import org.apache.maven.wagon.shared.http.ConfigurationUtils;
 import org.apache.maven.wagon.shared.http.HttpConfiguration;
 import org.apache.maven.wagon.shared.http.HttpMethodConfiguration;
+import org.junit.jupiter.api.Test;
 
-public class HttpClientWagonTest extends TestCase {
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
+public class HttpClientWagonTest {
+
+    @Test
     public void testSetMaxRedirectsParamViaConfig() {
         HttpMethodConfiguration methodConfig = new HttpMethodConfiguration();
         int maxRedirects = 2;
@@ -47,6 +52,7 @@ public class HttpClientWagonTest extends TestCase {
         assertEquals(2, requestConfig.getMaxRedirects());
     }
 
+    @Test
     public void testDefaultHeadersUsedByDefault() {
         HttpConfiguration config = new HttpConfiguration();
         config.setAll(new HttpMethodConfiguration());
@@ -71,6 +77,7 @@ public class HttpClientWagonTest extends TestCase {
         assertEquals("no-cache", header.getValue());
     }
 
+    @Test
     public void testTurnOffDefaultHeaders() {
         HttpConfiguration config = new HttpConfiguration();
         config.setAll(new HttpMethodConfiguration().setUseDefaultHeaders(false));

--- a/wagon-providers/wagon-http/src/test/java/org/apache/maven/wagon/providers/http/HugeFileDownloadTest.java
+++ b/wagon-providers/wagon-http/src/test/java/org/apache/maven/wagon/providers/http/HugeFileDownloadTest.java
@@ -35,7 +35,6 @@ import java.nio.file.StandardOpenOption;
 import org.apache.maven.wagon.Wagon;
 import org.apache.maven.wagon.observers.Debug;
 import org.apache.maven.wagon.repository.Repository;
-import org.codehaus.plexus.PlexusTestCase;
 import org.codehaus.plexus.util.IOUtil;
 import org.eclipse.jetty.server.HttpConfiguration;
 import org.eclipse.jetty.server.HttpConnectionFactory;
@@ -43,13 +42,16 @@ import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.ServerConnector;
 import org.eclipse.jetty.servlet.ServletContextHandler;
 import org.eclipse.jetty.servlet.ServletHolder;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * @author Olivier Lamy
  */
-public class HugeFileDownloadTest extends PlexusTestCase {
+public class HugeFileDownloadTest {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(HugeFileDownloadTest.class);
 
@@ -57,9 +59,15 @@ public class HugeFileDownloadTest extends PlexusTestCase {
             Integer.valueOf(Integer.MAX_VALUE).longValue()
                     + Integer.valueOf(Integer.MAX_VALUE).longValue();
 
+    private static String getBasedir() {
+        String basedir = System.getProperty("basedir");
+        return basedir != null ? basedir : new File("").getAbsolutePath();
+    }
+
     private Server server;
     private ServerConnector connector;
 
+    @Test
     public void testDownloadHugeFileWithContentLength() throws Exception {
         final File hugeFile = new File(getBasedir(), "target/hugefile.txt");
         if (!hugeFile.exists() || hugeFile.length() < HUGE_FILE_SIZE) {
@@ -109,6 +117,7 @@ public class HugeFileDownloadTest extends PlexusTestCase {
         }
     }
 
+    @Test
     public void testDownloadHugeFileWithChunked() throws Exception {
         final File hugeFile = new File(getBasedir(), "target/hugefile.txt");
         if (!hugeFile.exists() || hugeFile.length() < HUGE_FILE_SIZE) {
@@ -158,7 +167,7 @@ public class HugeFileDownloadTest extends PlexusTestCase {
     }
 
     protected Wagon getWagon() throws Exception {
-        Wagon wagon = (Wagon) lookup(Wagon.ROLE, "http");
+        Wagon wagon = new HttpWagon();
 
         Debug debug = new Debug();
 


### PR DESCRIPTION
Continues `a8cafa27` with the three tests in `wagon-http` that do not extend the bases published from
`wagon-provider-test`. Those bases stay on `PlexusTestCase`: external providers inherit their test
methods by the `testXxx()` convention, so moving them to `@Test` would leave any consumer on JUnit 4
running none of the inherited tests, with a green build.

`wagon-http` keeps `junit` and gains `junit-vintage-engine` alongside `junit-jupiter`. `HttpWagonTest`,
`HttpsWagonTest` and both Preemptive variants inherit from the published `HttpWagonTestCase` — 58 tests
each — and surefire provisions the jupiter engine but not the vintage one. No versions are needed;
`maven-parent` 49 imports `junit-bom`.

Nothing here needed `assertThrows` or Hamcrest work: no `@Test(expected=…)`, no `@Test(timeout=…)`, no
`@Ignore`, no `assertThat`, and no message-carrying assertions whose argument order would flip.

Verified: `mvn test` on `wagon-http` before and after, comparing per class. 295 test cases before, 295
after; the same two `proxied` tests skipped in both.

| | before | after |
|---|---|---|
| AbstractHttpClientWagonTest | 4 | 4 |
| BasicAuthScopeTest | 5 | 5 |
| HttpClientWagonTest | 3 | 3 |
| HttpWagonTest / HttpsWagonTest | 58 / 58 | 58 / 58 |
| HttpWagonPreemptiveTest / HttpsWagonPreemptiveTest | 58 / 58 | 58 / 58 |
| HttpWagonErrorTest / HttpWagonTimeoutTest | 5 / 4 | 5 / 4 |
| HugeFileDownloadTest / TckTest | 2 / 40 | 2 / 40 |

Worth knowing if you check this yourself: once the platform provider is in play, the `tests=`
attribute surefire writes for `TckTest` reads 20 rather than 40, because that class is a JUnit 4
`@RunWith(Suite.class)` aggregating two suites. The report still carries all 40 `<testcase>` elements
and both suites run — counting the attribute rather than the elements makes it look like twenty tests
were lost.

*This change was created with AI assistance.*