### PR TITLE
Migrate the standalone wagon-http tests to JUnit 5

### DIFF
--- a/wagon-providers/wagon-http/pom.xml
+++ b/wagon-providers/wagon-http/pom.xml
@@ -70,6 +70,17 @@ under the License.
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <!-- HttpWagonTest and its subclasses inherit JUnit 4 tests from the published HttpWagonTestCase -->
+    <dependency>
+      <groupId>org.junit.vintage</groupId>
+      <artifactId>junit-vintage-engine</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <scope>test</scope>

--- a/wagon-providers/wagon-http/src/test/java/org/apache/maven/wagon/providers/http/AbstractHttpClientWagonTest.java
+++ b/wagon-providers/wagon-http/src/test/java/org/apache/maven/wagon/providers/http/AbstractHttpClientWagonTest.java
@@ -42,19 +42,19 @@ import org.apache.maven.wagon.InputData;
 import org.apache.maven.wagon.repository.Repository;
 import org.apache.maven.wagon.resource.Resource;
 import org.apache.maven.wagon.shared.http.AbstractHttpClientWagon;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.CoreMatchers.instanceOf;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class AbstractHttpClientWagonTest {
-    @Ignore("This test is validating nothing and require internet connection which we should avoid so ignore it")
+    @Disabled("This test is validating nothing and require internet connection which we should avoid so ignore it")
     public void test() throws Exception {
         AbstractHttpClientWagon wagon = new AbstractHttpClientWagon() {};
 

--- a/wagon-providers/wagon-http/src/test/java/org/apache/maven/wagon/providers/http/BasicAuthScopeTest.java
+++ b/wagon-providers/wagon-http/src/test/java/org/apache/maven/wagon/providers/http/BasicAuthScopeTest.java
@@ -20,8 +20,9 @@ package org.apache.maven.wagon.providers.http;
 
 import org.apache.http.auth.AuthScope;
 import org.apache.maven.wagon.shared.http.BasicAuthScope;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class BasicAuthScopeTest {
 
@@ -34,9 +35,9 @@ public class BasicAuthScopeTest {
         BasicAuthScope scope = new BasicAuthScope();
 
         AuthScope authScope = scope.getScope("original.host.com", 3456);
-        Assert.assertEquals("original.host.com", authScope.getHost());
-        Assert.assertEquals(3456, authScope.getPort());
-        Assert.assertEquals(AuthScope.ANY_REALM, authScope.getRealm());
+        assertEquals("original.host.com", authScope.getHost());
+        assertEquals(3456, authScope.getPort());
+        assertEquals(AuthScope.ANY_REALM, authScope.getRealm());
     }
 
     /**
@@ -49,9 +50,9 @@ public class BasicAuthScopeTest {
         scope.setPort("1234");
         scope.setRealm("override-realm");
         AuthScope authScope = scope.getScope("original.host.com", 3456);
-        Assert.assertEquals("override.host.com", authScope.getHost());
-        Assert.assertEquals(1234, authScope.getPort());
-        Assert.assertEquals("override-realm", authScope.getRealm());
+        assertEquals("override.host.com", authScope.getHost());
+        assertEquals(1234, authScope.getPort());
+        assertEquals("override-realm", authScope.getRealm());
     }
 
     /**
@@ -64,9 +65,9 @@ public class BasicAuthScopeTest {
         scope.setPort("ANY");
         scope.setRealm("ANY");
         AuthScope authScope = scope.getScope("original.host.com", 3456);
-        Assert.assertEquals(AuthScope.ANY_HOST, authScope.getHost());
-        Assert.assertEquals(AuthScope.ANY_PORT, authScope.getPort());
-        Assert.assertEquals(AuthScope.ANY_REALM, authScope.getRealm());
+        assertEquals(AuthScope.ANY_HOST, authScope.getHost());
+        assertEquals(AuthScope.ANY_PORT, authScope.getPort());
+        assertEquals(AuthScope.ANY_REALM, authScope.getRealm());
     }
 
     /**
@@ -77,9 +78,9 @@ public class BasicAuthScopeTest {
         BasicAuthScope scope = new BasicAuthScope();
         scope.setRealm("override-realm");
         AuthScope authScope = scope.getScope("original.host.com", 3456);
-        Assert.assertEquals("original.host.com", authScope.getHost());
-        Assert.assertEquals(3456, authScope.getPort());
-        Assert.assertEquals("override-realm", authScope.getRealm());
+        assertEquals("original.host.com", authScope.getHost());
+        assertEquals(3456, authScope.getPort());
+        assertEquals("override-realm", authScope.getRealm());
     }
 
     /**
@@ -89,6 +90,6 @@ public class BasicAuthScopeTest {
     public void testGetScopeOriginalPortIsNegativeOne() {
         BasicAuthScope scope = new BasicAuthScope();
         AuthScope authScope = scope.getScope("original.host.com", -1);
-        Assert.assertEquals(AuthScope.ANY_PORT, authScope.getPort());
+        assertEquals(AuthScope.ANY_PORT, authScope.getPort());
     }
 }

--- a/wagon-providers/wagon-http/src/test/java/org/apache/maven/wagon/providers/http/HttpClientWagonTest.java
+++ b/wagon-providers/wagon-http/src/test/java/org/apache/maven/wagon/providers/http/HttpClientWagonTest.java
@@ -18,7 +18,6 @@
  */
 package org.apache.maven.wagon.providers.http;
 
-import junit.framework.TestCase;
 import org.apache.http.Header;
 import org.apache.http.client.config.RequestConfig;
 import org.apache.http.client.methods.HttpHead;
@@ -28,9 +27,15 @@ import org.apache.maven.wagon.shared.http.AbstractHttpClientWagon;
 import org.apache.maven.wagon.shared.http.ConfigurationUtils;
 import org.apache.maven.wagon.shared.http.HttpConfiguration;
 import org.apache.maven.wagon.shared.http.HttpMethodConfiguration;
+import org.junit.jupiter.api.Test;
 
-public class HttpClientWagonTest extends TestCase {
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
+public class HttpClientWagonTest {
+
+    @Test
     public void testSetMaxRedirectsParamViaConfig() {
         HttpMethodConfiguration methodConfig = new HttpMethodConfiguration();
         int maxRedirects = 2;
@@ -47,6 +52,7 @@ public class HttpClientWagonTest extends TestCase {
         assertEquals(2, requestConfig.getMaxRedirects());
     }
 
+    @Test
     public void testDefaultHeadersUsedByDefault() {
         HttpConfiguration config = new HttpConfiguration();
         config.setAll(new HttpMethodConfiguration());
@@ -71,6 +77,7 @@ public class HttpClientWagonTest extends TestCase {
         assertEquals("no-cache", header.getValue());
     }
 
+    @Test
     public void testTurnOffDefaultHeaders() {
         HttpConfiguration config = new HttpConfiguration();
         config.setAll(new HttpMethodConfiguration().setUseDefaultHeaders(false));

--- a/wagon-providers/wagon-http/src/test/java/org/apache/maven/wagon/providers/http/HugeFileDownloadTest.java
+++ b/wagon-providers/wagon-http/src/test/java/org/apache/maven/wagon/providers/http/HugeFileDownloadTest.java
@@ -35,7 +35,6 @@ import java.nio.file.StandardOpenOption;
 import org.apache.maven.wagon.Wagon;
 import org.apache.maven.wagon.observers.Debug;
 import org.apache.maven.wagon.repository.Repository;
-import org.codehaus.plexus.PlexusTestCase;
 import org.codehaus.plexus.util.IOUtil;
 import org.eclipse.jetty.server.HttpConfiguration;
 import org.eclipse.jetty.server.HttpConnectionFactory;
@@ -43,13 +42,16 @@ import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.ServerConnector;
 import org.eclipse.jetty.servlet.ServletContextHandler;
 import org.eclipse.jetty.servlet.ServletHolder;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * @author Olivier Lamy
  */
-public class HugeFileDownloadTest extends PlexusTestCase {
+public class HugeFileDownloadTest {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(HugeFileDownloadTest.class);
 
@@ -57,9 +59,15 @@ public class HugeFileDownloadTest extends PlexusTestCase {
             Integer.valueOf(Integer.MAX_VALUE).longValue()
                     + Integer.valueOf(Integer.MAX_VALUE).longValue();
 
+    private static String getBasedir() {
+        String basedir = System.getProperty("basedir");
+        return basedir != null ? basedir : new File("").getAbsolutePath();
+    }
+
     private Server server;
     private ServerConnector connector;
 
+    @Test
     public void testDownloadHugeFileWithContentLength() throws Exception {
         final File hugeFile = new File(getBasedir(), "target/hugefile.txt");
         if (!hugeFile.exists() || hugeFile.length() < HUGE_FILE_SIZE) {
@@ -109,6 +117,7 @@ public class HugeFileDownloadTest extends PlexusTestCase {
         }
     }
 
+    @Test
     public void testDownloadHugeFileWithChunked() throws Exception {
         final File hugeFile = new File(getBasedir(), "target/hugefile.txt");
         if (!hugeFile.exists() || hugeFile.length() < HUGE_FILE_SIZE) {
@@ -158,7 +167,7 @@ public class HugeFileDownloadTest extends PlexusTestCase {
     }
 
     protected Wagon getWagon() throws Exception {
-        Wagon wagon = (Wagon) lookup(Wagon.ROLE, "http");
+        Wagon wagon = new HttpWagon();
 
         Debug debug = new Debug();
 


### PR DESCRIPTION
Backport of #928. Only tests that do not extend the bases published from `wagon-provider-test` move;
those bases stay on `PlexusTestCase`, since external providers inherit their test methods by the
`testXxx()` convention and would silently run none of them.

`wagon-http` keeps `junit` and gains `junit-vintage-engine` alongside `junit-jupiter`. `HttpWagonTest`,
`HttpsWagonTest` and both Preemptive variants inherit from the published `HttpWagonTestCase` — 58 tests
each — and surefire provisions the jupiter engine but not the vintage one.

`BasicAuthScopeTest` and `HttpClientWagonTest` are byte-identical to master's pre-migration state, so
master's reviewed result is taken verbatim. `AbstractHttpClientWagonTest` has drifted here and needed
two things master never faced: JUnit 5 has no `Assertions.assertThat`, so its four uses move to
`org.hamcrest.MatcherAssert` (Hamcrest stays available through `junit` 4.13.2, which this module keeps);
and `@Ignore` becomes `@Disabled` on a method that carries no `@Test` and so never ran under either
framework.

### Verification

`mvn test` on `wagon-http`, comparing `<testcase>` elements per class rather than the `tests=`
attribute: **295 before, 295 after**, same per class, 2 skipped in both.

Both runs end with one error, and it is not the same test:

| | error |
|---|---|
| before | `HttpsWagonTest.testSecuredPutUnauthorized` |
| after | `HttpWagonTest.testProxiedRequest` |

That is order-dependent interference between these classes, which share a static `HttpClient` and proxy
system properties, not something this change introduces. Run on its own, `HttpWagonTest` is 58 tests and
0 errors on **both** trees — unmigrated and migrated. The engine switch changes execution order, so a
different order-dependent test is the one that loses. Worth knowing when reading CI here; it is a
pre-existing fragility in these tests and is not addressed by this PR.

One reporting quirk if you re-run this yourself: once the platform provider is active, the `tests=`
attribute surefire writes for `TckTest` reads 20 rather than 40, because that class is a JUnit 4
`@RunWith(Suite.class)` aggregating two suites. All 40 `<testcase>` elements are present and both suites
run — counting the attribute makes it look like twenty tests vanished.

*This change was created with AI assistance.*