### PR TITLE
Migrate HttpWagonHttpServerTestCase and its subclasses off PlexusTestCase

### DIFF
--- a/wagon-providers/wagon-http/src/test/java/org/apache/maven/wagon/providers/http/HttpWagonErrorTest.java
+++ b/wagon-providers/wagon-http/src/test/java/org/apache/maven/wagon/providers/http/HttpWagonErrorTest.java
@@ -27,6 +27,11 @@ import org.apache.maven.wagon.Wagon;
 import org.apache.maven.wagon.authorization.AuthorizationException;
 import org.apache.maven.wagon.repository.Repository;
 import org.eclipse.jetty.servlet.ServletHolder;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 /**
  * User: jdumay Date: 24/01/2008 Time: 17:17:34
@@ -34,14 +39,15 @@ import org.eclipse.jetty.servlet.ServletHolder;
 public class HttpWagonErrorTest extends HttpWagonHttpServerTestCase {
     private int serverPort;
 
+    @BeforeEach
     protected void setUp() throws Exception {
-        super.setUp();
         ServletHolder servlets = new ServletHolder(new ErrorWithMessageServlet());
         context.addServlet(servlets, "/*");
         startServer();
         serverPort = getPort();
     }
 
+    @Test
     public void testGet401() throws Exception {
         Exception thrown = null;
 
@@ -73,6 +79,7 @@ public class HttpWagonErrorTest extends HttpWagonHttpServerTestCase {
                 thrown.getMessage());
     }
 
+    @Test
     public void testGet403() throws Exception {
         Exception thrown = null;
 
@@ -104,6 +111,7 @@ public class HttpWagonErrorTest extends HttpWagonHttpServerTestCase {
                 thrown.getMessage());
     }
 
+    @Test
     public void testGet404() throws Exception {
         Exception thrown = null;
 
@@ -135,6 +143,7 @@ public class HttpWagonErrorTest extends HttpWagonHttpServerTestCase {
                 thrown.getMessage());
     }
 
+    @Test
     public void testGet407() throws Exception {
         Exception thrown = null;
 
@@ -166,6 +175,7 @@ public class HttpWagonErrorTest extends HttpWagonHttpServerTestCase {
                 thrown.getMessage());
     }
 
+    @Test
     public void testGet500() throws Exception {
         Exception thrown = null;
 

--- a/wagon-providers/wagon-http/src/test/java/org/apache/maven/wagon/providers/http/HttpWagonHttpServerTestCase.java
+++ b/wagon-providers/wagon-http/src/test/java/org/apache/maven/wagon/providers/http/HttpWagonHttpServerTestCase.java
@@ -18,25 +18,31 @@
  */
 package org.apache.maven.wagon.providers.http;
 
+import java.lang.reflect.Method;
+
 import org.apache.maven.wagon.Wagon;
-import org.codehaus.plexus.PlexusTestCase;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.ServerConnector;
 import org.eclipse.jetty.server.handler.ResourceHandler;
 import org.eclipse.jetty.servlet.ServletContextHandler;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.TestInfo;
 
 /**
  * User: jdumay Date: 24/01/2008 Time: 18:15:53
  */
-public abstract class HttpWagonHttpServerTestCase extends PlexusTestCase {
+public abstract class HttpWagonHttpServerTestCase {
     private Server server;
+
+    private String testName;
 
     protected ResourceHandler resourceHandler;
 
     protected ServletContextHandler context;
 
-    protected void setUp() throws Exception {
-        super.setUp();
+    @BeforeEach
+    protected void startTestServer(TestInfo testInfo) throws Exception {
+        testName = testInfo.getTestMethod().map(Method::getName).orElseGet(testInfo::getDisplayName);
         server = new Server(0);
 
         context = new ServletContextHandler(ServletContextHandler.SESSIONS);
@@ -45,8 +51,12 @@ public abstract class HttpWagonHttpServerTestCase extends PlexusTestCase {
         server.setHandler(context);
     }
 
+    protected final String getName() {
+        return testName;
+    }
+
     protected Wagon getWagon() throws Exception {
-        return (Wagon) lookup(HttpWagon.ROLE);
+        return new HttpWagon();
     }
 
     protected void startServer() throws Exception {

--- a/wagon-providers/wagon-http/src/test/java/org/apache/maven/wagon/providers/http/HttpWagonTimeoutTest.java
+++ b/wagon-providers/wagon-http/src/test/java/org/apache/maven/wagon/providers/http/HttpWagonTimeoutTest.java
@@ -28,18 +28,25 @@ import org.apache.maven.wagon.repository.Repository;
 import org.apache.maven.wagon.shared.http.HttpConfiguration;
 import org.apache.maven.wagon.shared.http.HttpMethodConfiguration;
 import org.eclipse.jetty.servlet.ServletHolder;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * User: jdumay Date: 24/01/2008 Time: 17:17:34
  */
 public class HttpWagonTimeoutTest extends HttpWagonHttpServerTestCase {
+    @BeforeEach
     protected void setUp() throws Exception {
-        super.setUp();
         ServletHolder servlets = new ServletHolder(new WaitForeverServlet());
         context.addServlet(servlets, "/*");
         startServer();
     }
 
+    @Test
     public void testGetTimeout() throws Exception {
         Exception thrown = null;
 
@@ -68,6 +75,7 @@ public class HttpWagonTimeoutTest extends HttpWagonHttpServerTestCase {
         assertEquals(TransferFailedException.class, thrown.getClass());
     }
 
+    @Test
     public void testResourceExits() throws Exception {
         Exception thrown = null;
 
@@ -93,6 +101,7 @@ public class HttpWagonTimeoutTest extends HttpWagonHttpServerTestCase {
         assertEquals(TransferFailedException.class, thrown.getClass());
     }
 
+    @Test
     public void testPutTimeout() throws Exception {
         Exception thrown = null;
 
@@ -121,6 +130,7 @@ public class HttpWagonTimeoutTest extends HttpWagonHttpServerTestCase {
         assertEquals(TransferFailedException.class, thrown.getClass());
     }
 
+    @Test
     public void testConnectionTimeout() throws Exception {
         Exception thrown = null;
 


### PR DESCRIPTION
Backport of #930. This branch's three copies were byte-identical to master's before its migration, so
master's result is taken verbatim.

No new dependency: the container was only supplying `Wagon.ROLE`, which is `HttpWagon`, and
`AbstractHttpClientWagon` declares no injected collaborators.

Two details worth a look, same as on master:

- The base lifecycle method is renamed `startTestServer`. Left as `setUp()`, the subclasses' own
  `setUp()` would override it and JUnit 5 would run only the override, so the Jetty server would never
  be created. With distinct names JUnit 5 runs the superclass `@BeforeEach` first in its own right and
  the subclasses drop their `super.setUp()` call.
- `getName()` came from `junit.framework.TestCase` and feeds six `FileTestUtils.createUniqueFile` call
  sites; it now comes from an injected `TestInfo`, leaving those unchanged.

Verified: `mvn test` on `wagon-http`, counting `<testcase>` elements per class — 295 before and after,
2 skipped in both, zero failures. `HttpWagonErrorTest` stays at 5 and `HttpWagonTimeoutTest` at 4,
which is what shows the base setup still runs.

*This change was created with AI assistance.*