### PR TITLE
Migrate ScpWagonWithProxyTest off PlexusTestCase

### DIFF
--- a/wagon-providers/wagon-ssh/pom.xml
+++ b/wagon-providers/wagon-ssh/pom.xml
@@ -93,6 +93,23 @@ under the License.
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.codehaus.plexus</groupId>
+      <artifactId>plexus-testing</artifactId>
+      <version>2.1.0</version>
+      <scope>test</scope>
+    </dependency>
+    <!-- ScpWagonTest and its siblings inherit JUnit 4 tests from the published WagonTestCase -->
+    <dependency>
+      <groupId>org.junit.vintage</groupId>
+      <artifactId>junit-vintage-engine</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <scope>test</scope>

--- a/wagon-providers/wagon-ssh/src/test/java/org/apache/maven/wagon/providers/ssh/jsch/ScpWagonWithProxyTest.java
+++ b/wagon-providers/wagon-ssh/src/test/java/org/apache/maven/wagon/providers/ssh/jsch/ScpWagonWithProxyTest.java
@@ -18,6 +18,8 @@
  */
 package org.apache.maven.wagon.providers.ssh.jsch;
 
+import javax.inject.Inject;
+import javax.inject.Named;
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -34,7 +36,8 @@ import org.apache.maven.wagon.proxy.ProxyInfo;
 import org.apache.maven.wagon.repository.Repository;
 import org.codehaus.plexus.ContainerConfiguration;
 import org.codehaus.plexus.PlexusConstants;
-import org.codehaus.plexus.PlexusTestCase;
+import org.codehaus.plexus.testing.PlexusTest;
+import org.codehaus.plexus.testing.PlexusTestConfiguration;
 import org.eclipse.jetty.server.Handler;
 import org.eclipse.jetty.server.HttpConfiguration;
 import org.eclipse.jetty.server.HttpConnectionFactory;
@@ -42,16 +45,29 @@ import org.eclipse.jetty.server.Request;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.ServerConnector;
 import org.eclipse.jetty.server.handler.AbstractHandler;
+import org.junit.jupiter.api.Test;
 
-public class ScpWagonWithProxyTest extends PlexusTestCase {
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+@PlexusTest
+public class ScpWagonWithProxyTest implements PlexusTestConfiguration {
     @Override
-    protected void customizeContainerConfiguration(ContainerConfiguration configuration) {
+    public void customizeConfiguration(ContainerConfiguration configuration) {
         // the providers are @Named beans now, so the container has to read META-INF/sisu
         configuration.setClassPathScanning(PlexusConstants.SCANNING_INDEX);
     }
 
+    // injected by the container so the wagon keeps the collaborators AbstractJschWagon
+    // declares with @Inject; constructing it directly would leave them null
+    @Inject
+    @Named("scp")
+    private Wagon wagon;
+
     private boolean handled;
 
+    @Test
     public void testHttpProxy() throws Exception {
         handled = false;
         Handler handler = new AbstractHandler() {
@@ -78,7 +94,6 @@ public class ScpWagonWithProxyTest extends PlexusTestCase {
         proxyInfo.setType("http");
         proxyInfo.setNonProxyHosts(null);
 
-        Wagon wagon = (Wagon) lookup(Wagon.ROLE, "scp");
         try {
             wagon.connect(new Repository("id", "scp://localhost/tmp"), proxyInfo);
             fail();
@@ -90,6 +105,7 @@ public class ScpWagonWithProxyTest extends PlexusTestCase {
         }
     }
 
+    @Test
     public void testSocksProxy() throws Exception {
         handled = false;
 
@@ -106,7 +122,6 @@ public class ScpWagonWithProxyTest extends PlexusTestCase {
         proxyInfo.setType("socks_5");
         proxyInfo.setNonProxyHosts(null);
 
-        Wagon wagon = (Wagon) lookup(Wagon.ROLE, "scp");
         try {
             wagon.connect(new Repository("id", "scp://localhost/tmp"), proxyInfo);
             fail();


### PR DESCRIPTION
Backport of #931. This branch's copy was byte-identical to master's before its migration, so master's
result is taken verbatim; the pom drift between the branches is only the version line, so the three
dependencies are replayed rather than the file lifted.

Unlike the other providers migrated so far, this one genuinely needs a container. `AbstractJschWagon`
declares `knownHostsProvider` \(`@Named("file")`\), `interactiveUserInfo` and `uIKeyboardInteractive`
with `@Inject`; constructing the wagon directly would leave all three null and the test would keep
passing while exercising something different. Hence `plexus-testing` with `@Inject @Named("scp")`, and
`PlexusTestConfiguration` to carry over the `SCANNING_INDEX` setting the sisu-annotated providers need.

`wagon-ssh` also gains `junit-vintage-engine`: `ScpWagonTest`, `SftpWagonTest`,
`EmbeddedScpWagonWithKeyTest`, `SshCommandExecutorTest` and `ScpWagonWithSshPrivateKeySearchTest` still
inherit their test methods from the published `WagonTestCase`.

### Verification, including its limit

This module excludes every one of its test classes from surefire — `**/ScpWagon*Test.*` covers this
one — so `mvn test` in `wagon-ssh` runs nothing and reports success either way. Passing `-Dtest`
overrides the exclusion, which makes a real comparison possible on this branch:

| | cases | errors | failures |
|---|---|---|---|
| before | 2 | 0 | 2 |
| after | 2 | 0 | 2 |

Identical, matching what #931 measured on master. Both fail on `assertTrue(handled)` because the proxy
is never reached without an ssh server present, which is what the exclusions exist for.

That identity is also the evidence that the injection works: had `@Inject @Named("scp")` not resolved,
the run would have produced NPE **errors**, not the same two assertion **failures** — the test only
reaches that assertion after `wagon.connect(...)` has thrown `AuthenticationException`.

*This change was created with AI assistance.*