### PR TITLE
Halve the file HugeFileDownloadTest transfers

### DIFF
--- a/wagon-providers/wagon-http/src/test/java/org/apache/maven/wagon/providers/http/HugeFileDownloadTest.java
+++ b/wagon-providers/wagon-http/src/test/java/org/apache/maven/wagon/providers/http/HugeFileDownloadTest.java
@@ -55,9 +55,12 @@ public class HugeFileDownloadTest {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(HugeFileDownloadTest.class);
 
-    private static final long HUGE_FILE_SIZE =
-            Integer.valueOf(Integer.MAX_VALUE).longValue()
-                    + Integer.valueOf(Integer.MAX_VALUE).longValue();
+    /**
+     * Just past the 2 GiB mark, which is what this test is about: a byte count held in an int
+     * overflows above Integer.MAX_VALUE. Twice that only doubles the transfer without widening
+     * the range of the check.
+     */
+    private static final long HUGE_FILE_SIZE = Integer.MAX_VALUE + 1024L;
 
     private static String getBasedir() {
         String basedir = System.getProperty("basedir");


### PR DESCRIPTION
`HugeFileDownloadTest` exists to catch a byte count held in an `int`, which overflows above
`Integer.MAX_VALUE`. The constant was set to twice that, so every run transferred ~4 GiB rather than
the ~2 GiB the check actually needs — double the cost for the same coverage. It is now
`Integer.MAX_VALUE + 1024L`, still past the boundary, with the reasoning written on the constant so it
does not get rounded back up.

The file itself is sparse, so this changes the transfer, not the disk footprint.

Measured on the class alone, deleting `target/hugefile.txt` first so the file is recreated each time:

| | time | cases | failures |
|---|---|---|---|
| before | 29.98s | 2 | 0 |
| after | 5.47s | 2 | 0 |
| after, second run | 5.50s | 2 | 0 |

Worth being straight about the scale: that is a real saving but a small share of a Verify run, which
has been taking 22–25 minutes on this repo for a while. The larger costs are `TckTest` at 56.6s and
the Jetty/TLS classes — `HttpsWagonTest` 31.7s, `HttpWagonPreemptiveTest` 29.6s,
`HttpsWagonPreemptiveTest` 30.1s, `HttpWagonTest` 29.5s — and those are inherent to what they test.

*This change was created with AI assistance.*