### PR TITLE
Halve the file HugeFileDownloadTest transfers

### DIFF
--- a/wagon-providers/wagon-http/src/test/java/org/apache/maven/wagon/providers/http/HugeFileDownloadTest.java
+++ b/wagon-providers/wagon-http/src/test/java/org/apache/maven/wagon/providers/http/HugeFileDownloadTest.java
@@ -55,9 +55,12 @@ public class HugeFileDownloadTest {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(HugeFileDownloadTest.class);
 
-    private static final long HUGE_FILE_SIZE =
-            Integer.valueOf(Integer.MAX_VALUE).longValue()
-                    + Integer.valueOf(Integer.MAX_VALUE).longValue();
+    /**
+     * Just past the 2 GiB mark, which is what this test is about: a byte count held in an int
+     * overflows above Integer.MAX_VALUE. Twice that only doubles the transfer without widening
+     * the range of the check.
+     */
+    private static final long HUGE_FILE_SIZE = Integer.MAX_VALUE + 1024L;
 
     private static String getBasedir() {
         String basedir = System.getProperty("basedir");


### PR DESCRIPTION
Backport of #934. This branch's copy was identical to master's before that change, so it applies
verbatim.

`HugeFileDownloadTest` exists to catch a byte count held in an `int`, which overflows above
`Integer.MAX_VALUE`. The constant was set to twice that, so every run transferred ~4 GiB rather than
the ~2 GiB the check needs. It is now `Integer.MAX_VALUE + 1024L`, still past the boundary, with the
reasoning written on the constant. The file is sparse, so this changes transfer time, not disk use.

Measured on this branch, on the class alone, deleting `target/hugefile.txt` first so it is recreated:

| | time | cases | failures |
|---|---|---|---|
| before | 12.70s | 2 | 0 |
| after | 5.08s | 2 | 0 |

The before figure is lower than the 29.98s measured on master for the same starting code — same
machine, so treat these as one machine's numbers rather than a benchmark; the direction and the
reason for it are what matter.

*This change was created with AI assistance.*