### PR TITLE
Migrate the published test base classes off PlexusTestCase

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -196,6 +196,11 @@ under the License.
       </dependency>
       <dependency>
         <groupId>org.codehaus.plexus</groupId>
+        <artifactId>plexus-testing</artifactId>
+        <version>2.1.0</version>
+      </dependency>
+      <dependency>
+        <groupId>org.codehaus.plexus</groupId>
         <artifactId>plexus-interactivity-api</artifactId>
         <version>1.5.1</version>
       </dependency>
@@ -296,6 +301,13 @@ under the License.
       </plugins>
     </pluginManagement>
     <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-checkstyle-plugin</artifactId>
+        <configuration>
+          <suppressionsLocation>src/config/checkstyle-suppressions.xml</suppressionsLocation>
+        </configuration>
+      </plugin>
       <!-- indexes the @Named beans into META-INF/sisu; executions come from maven-parent -->
       <plugin>
         <groupId>org.eclipse.sisu</groupId>

--- a/src/config/checkstyle-suppressions.xml
+++ b/src/config/checkstyle-suppressions.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-->
+<!DOCTYPE suppressions PUBLIC
+    "-//Checkstyle//DTD SuppressionFilter Configuration 1.2//EN"
+    "https://checkstyle.org/dtds/suppressions_1_2.dtd">
+<suppressions>
+  <!--
+    FileLength is a Checker-level check reported at line 1, so neither @SuppressWarnings nor a
+    CHECKSTYLE_OFF comment can suppress it: the annotation is only seen by TreeWalker, and a
+    line-1 comment is removed by spotless, which requires the licence header first. Adding one
+    @Test per test method took this class one line past the inherited 2000-line limit; splitting
+    it is a separate change.
+  -->
+  <suppress checks="FileLength" files="HttpWagonTestCase\.java"/>
+</suppressions>

--- a/wagon-provider-test/pom.xml
+++ b/wagon-provider-test/pom.xml
@@ -31,6 +31,12 @@ under the License.
   <description>Suite of tests for Wagon implementations</description>
 
   <dependencies>
+    <!-- WagonTestCase and CommandExecutorTestCase are published here and use @PlexusTest,
+         so this is compile scope rather than test scope -->
+    <dependency>
+      <groupId>org.codehaus.plexus</groupId>
+      <artifactId>plexus-testing</artifactId>
+    </dependency>
     <dependency>
       <groupId>org.apache.maven.wagon</groupId>
       <artifactId>wagon-provider-api</artifactId>
@@ -39,6 +45,10 @@ under the License.
       <groupId>org.eclipse.sisu</groupId>
       <artifactId>org.eclipse.sisu.plexus</artifactId>
       <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
     </dependency>
     <dependency>
       <groupId>com.google.inject</groupId>
@@ -66,11 +76,6 @@ under the License.
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <scope>compile</scope>
     </dependency>
   </dependencies>
 </project>

--- a/wagon-provider-test/src/main/java/org/apache/maven/wagon/CommandExecutorTestCase.java
+++ b/wagon-provider-test/src/main/java/org/apache/maven/wagon/CommandExecutorTestCase.java
@@ -18,11 +18,19 @@
  */
 package org.apache.maven.wagon;
 
+import javax.inject.Inject;
+
 import org.apache.maven.wagon.authentication.AuthenticationInfo;
 import org.apache.maven.wagon.repository.Repository;
 import org.codehaus.plexus.ContainerConfiguration;
 import org.codehaus.plexus.PlexusConstants;
-import org.codehaus.plexus.PlexusTestCase;
+import org.codehaus.plexus.PlexusContainer;
+import org.codehaus.plexus.testing.PlexusTest;
+import org.codehaus.plexus.testing.PlexusTestConfiguration;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * Base class for command executor tests.
@@ -30,15 +38,21 @@ import org.codehaus.plexus.PlexusTestCase;
  * @author <a href="mailto:brett@apache.org">Brett Porter</a>
  *
  */
-public abstract class CommandExecutorTestCase extends PlexusTestCase {
+@PlexusTest
+public abstract class CommandExecutorTestCase implements PlexusTestConfiguration {
+
+    @Inject
+    private PlexusContainer container;
+
     @Override
-    protected void customizeContainerConfiguration(ContainerConfiguration configuration) {
+    public void customizeConfiguration(ContainerConfiguration configuration) {
         // the providers are @Named beans now, so the container has to read META-INF/sisu
         configuration.setClassPathScanning(PlexusConstants.SCANNING_INDEX);
     }
 
+    @Test
     public void testErrorInCommandExecuted() throws Exception {
-        CommandExecutor exec = (CommandExecutor) lookup(CommandExecutor.ROLE);
+        CommandExecutor exec = container.lookup(CommandExecutor.class);
 
         Repository repository = getTestRepository();
 
@@ -57,8 +71,9 @@ public abstract class CommandExecutorTestCase extends PlexusTestCase {
         }
     }
 
+    @Test
     public void testIgnoreFailuresInCommandExecuted() throws Exception {
-        CommandExecutor exec = (CommandExecutor) lookup(CommandExecutor.ROLE);
+        CommandExecutor exec = container.lookup(CommandExecutor.class);
 
         Repository repository = getTestRepository();
 
@@ -76,8 +91,9 @@ public abstract class CommandExecutorTestCase extends PlexusTestCase {
         }
     }
 
+    @Test
     public void testExecuteSuccessfulCommand() throws Exception {
-        CommandExecutor exec = (CommandExecutor) lookup(CommandExecutor.ROLE);
+        CommandExecutor exec = container.lookup(CommandExecutor.class);
 
         Repository repository = getTestRepository();
 

--- a/wagon-provider-test/src/main/java/org/apache/maven/wagon/StreamingWagonTestCase.java
+++ b/wagon-provider-test/src/main/java/org/apache/maven/wagon/StreamingWagonTestCase.java
@@ -29,13 +29,19 @@ import java.text.SimpleDateFormat;
 
 import org.apache.maven.wagon.observers.ChecksumObserver;
 import org.apache.maven.wagon.resource.Resource;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * @author <a href="mailto:brett@apache.org">Brett Porter</a>
  */
 public abstract class StreamingWagonTestCase extends WagonTestCase {
+    @Test
     public void testStreamingWagon() throws Exception {
         if (supportsGetIfNewer()) {
             setupWagonTestingFixtures();
@@ -48,6 +54,7 @@ public abstract class StreamingWagonTestCase extends WagonTestCase {
         }
     }
 
+    @Test
     public void testFailedGetToStream() throws Exception {
         setupWagonTestingFixtures();
 
@@ -80,6 +87,7 @@ public abstract class StreamingWagonTestCase extends WagonTestCase {
         }
     }
 
+    @Test
     public void testWagonGetIfNewerToStreamIsNewer() throws Exception {
         if (supportsGetIfNewer()) {
             setupWagonTestingFixtures();
@@ -93,6 +101,7 @@ public abstract class StreamingWagonTestCase extends WagonTestCase {
         }
     }
 
+    @Test
     public void testWagonGetIfNewerToStreamIsOlder() throws Exception {
         if (supportsGetIfNewer()) {
             setupWagonTestingFixtures();
@@ -103,6 +112,7 @@ public abstract class StreamingWagonTestCase extends WagonTestCase {
         }
     }
 
+    @Test
     public void testWagonGetIfNewerToStreamIsSame() throws Exception {
         if (supportsGetIfNewer()) {
             setupWagonTestingFixtures();
@@ -136,6 +146,7 @@ public abstract class StreamingWagonTestCase extends WagonTestCase {
         tearDownWagonTestingFixtures();
     }
 
+    @Test
     public void testFailedGetIfNewerToStream() throws Exception {
         if (supportsGetIfNewer()) {
             setupWagonTestingFixtures();
@@ -168,17 +179,17 @@ public abstract class StreamingWagonTestCase extends WagonTestCase {
 
         int expectedSize = putStream();
 
-        assertNotNull("check checksum is not null", checksumObserver.getActualChecksum());
+        assertNotNull(checksumObserver.getActualChecksum(), "check checksum is not null");
 
-        assertEquals("compare checksums", "6b144b7285ffd6b0bc8300da162120b9", checksumObserver.getActualChecksum());
+        assertEquals("6b144b7285ffd6b0bc8300da162120b9", checksumObserver.getActualChecksum(), "compare checksums");
 
         checksumObserver = new ChecksumObserver();
 
         getStream(expectedSize);
 
-        assertNotNull("check checksum is not null", checksumObserver.getActualChecksum());
+        assertNotNull(checksumObserver.getActualChecksum(), "check checksum is not null");
 
-        assertEquals("compare checksums", "6b144b7285ffd6b0bc8300da162120b9", checksumObserver.getActualChecksum());
+        assertEquals("6b144b7285ffd6b0bc8300da162120b9", checksumObserver.getActualChecksum(), "compare checksums");
 
         // Now compare the contents of the artifact that was placed in
         // the repository with the contents of the artifact that was

--- a/wagon-provider-test/src/main/java/org/apache/maven/wagon/WagonTestCase.java
+++ b/wagon-provider-test/src/main/java/org/apache/maven/wagon/WagonTestCase.java
@@ -18,8 +18,11 @@
  */
 package org.apache.maven.wagon;
 
+import javax.inject.Inject;
+
 import java.io.File;
 import java.io.IOException;
+import java.lang.reflect.Method;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.security.NoSuchAlgorithmException;
@@ -40,15 +43,27 @@ import org.apache.maven.wagon.repository.RepositoryPermissions;
 import org.apache.maven.wagon.resource.Resource;
 import org.codehaus.plexus.ContainerConfiguration;
 import org.codehaus.plexus.PlexusConstants;
-import org.codehaus.plexus.PlexusTestCase;
+import org.codehaus.plexus.PlexusContainer;
+import org.codehaus.plexus.testing.PlexusExtension;
+import org.codehaus.plexus.testing.PlexusTest;
+import org.codehaus.plexus.testing.PlexusTestConfiguration;
 import org.codehaus.plexus.util.FileUtils;
-import org.junit.Assume;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static org.junit.Assert.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.eq;
@@ -58,9 +73,10 @@ import static org.mockito.Mockito.mock;
 /**
  * @author <a href="mailto:jason@maven.org">Jason van Zyl</a>
  */
-public abstract class WagonTestCase extends PlexusTestCase {
+@PlexusTest
+public abstract class WagonTestCase implements PlexusTestConfiguration {
     @Override
-    protected void customizeContainerConfiguration(ContainerConfiguration configuration) {
+    public void customizeConfiguration(ContainerConfiguration configuration) {
         // the providers are @Named beans now, so the container has to read META-INF/sisu
         configuration.setClassPathScanning(PlexusConstants.SCANNING_INDEX);
     }
@@ -99,8 +115,6 @@ public abstract class WagonTestCase extends PlexusTestCase {
 
     protected String resource;
 
-    protected boolean testSkipped;
-
     protected File artifactSourceFile;
 
     protected File artifactDestFile;
@@ -113,12 +127,47 @@ public abstract class WagonTestCase extends PlexusTestCase {
     // Constructors
     // ----------------------------------------------------------------------
 
-    protected void setUp() throws Exception {
+    /** The hint is only known at run time, so this needs the container rather than @Named. */
+    @Inject
+    private PlexusContainer container;
+
+    private String testName;
+
+    /** Replaces TestCase.getName(), which the subclasses use to build unique file names. */
+    protected final String getName() {
+        return testName;
+    }
+
+    /** Was inherited from PlexusTestCase; plexus-testing keeps it on PlexusExtension. */
+    protected static File getTestFile(String path) {
+        return PlexusExtension.getTestFile(path);
+    }
+
+    /** Was inherited from PlexusTestCase; plexus-testing keeps it on PlexusExtension. */
+    protected static String getTestPath(String path) {
+        return PlexusExtension.getTestPath(path);
+    }
+
+    /** Was inherited from PlexusTestCase; plexus-testing keeps it on PlexusExtension. */
+    protected static String getBasedir() {
+        return PlexusExtension.getBasedir();
+    }
+
+    /**
+     * Kept as its own callback rather than a parameter on setUp: eight subclasses override setUp()
+     * and call super.setUp(), and widening that signature would break every one of them. A
+     * superclass @BeforeEach runs before the subclass's, so the name is set in time.
+     */
+    @BeforeEach
+    final void captureTestName(TestInfo testInfo) {
+        testName = testInfo.getTestMethod().map(Method::getName).orElseGet(testInfo::getDisplayName);
+    }
+
+    @BeforeEach
+    public void setUp() throws Exception {
         checksumObserver = new ChecksumObserver();
 
         mockTransferListener = mock(TransferListener.class);
-
-        super.setUp();
     }
 
     // ----------------------------------------------------------------------
@@ -195,7 +244,7 @@ public abstract class WagonTestCase extends PlexusTestCase {
     }
 
     protected Wagon getWagon() throws Exception {
-        Wagon wagon = (Wagon) lookup(Wagon.ROLE, getProtocol());
+        Wagon wagon = container.lookup(Wagon.class, getProtocol());
 
         Debug debug = new Debug();
 
@@ -228,6 +277,7 @@ public abstract class WagonTestCase extends PlexusTestCase {
     //
     // ----------------------------------------------------------------------
 
+    @Test
     public void testWagon() throws Exception {
         setupWagonTestingFixtures();
 
@@ -238,6 +288,7 @@ public abstract class WagonTestCase extends PlexusTestCase {
         tearDownWagonTestingFixtures();
     }
 
+    @Test
     public void testWagonGetIfNewerIsNewer() throws Exception {
         if (supportsGetIfNewer()) {
             setupWagonTestingFixtures();
@@ -250,17 +301,11 @@ public abstract class WagonTestCase extends PlexusTestCase {
         }
     }
 
-    @Override
-    protected void runTest() throws Throwable {
-        if (!testSkipped) {
-            super.runTest();
-        }
-    }
-
     protected boolean supportsGetIfNewer() {
         return true;
     }
 
+    @Test
     public void testWagonGetIfNewerIsSame() throws Exception {
         if (supportsGetIfNewer()) {
             setupWagonTestingFixtures();
@@ -270,6 +315,7 @@ public abstract class WagonTestCase extends PlexusTestCase {
         }
     }
 
+    @Test
     public void testWagonGetIfNewerIsOlder() throws Exception {
         if (supportsGetIfNewer()) {
             setupWagonTestingFixtures();
@@ -319,9 +365,9 @@ public abstract class WagonTestCase extends PlexusTestCase {
         if (expectedResult) {
             assertEquals(expectedSize, progressAnswer.getSize());
 
-            assertNotNull("check checksum is not null", checksumObserver.getActualChecksum());
+            assertNotNull(checksumObserver.getActualChecksum(), "check checksum is not null");
 
-            assertEquals("compare checksums", TEST_CKSUM, checksumObserver.getActualChecksum());
+            assertEquals(TEST_CKSUM, checksumObserver.getActualChecksum(), "compare checksums");
 
             // Now compare the contents of the artifact that was placed in
             // the repository with the contents of the artifact that was
@@ -331,7 +377,7 @@ public abstract class WagonTestCase extends PlexusTestCase {
             byte[] destContent = Files.readAllBytes(destFile.toPath());
             assertArrayEquals(sourceContent, destContent);
         } else {
-            assertNull("check checksum is null", checksumObserver.getActualChecksum());
+            assertNull(checksumObserver.getActualChecksum(), "check checksum is null");
 
             assertFalse(destFile.exists());
         }
@@ -349,6 +395,7 @@ public abstract class WagonTestCase extends PlexusTestCase {
         // TransferEvent.REQUEST_GET, destFile ) );
     }
 
+    @Test
     public void testWagonPutDirectory() throws Exception {
         setupWagonTestingFixtures();
 
@@ -394,6 +441,7 @@ public abstract class WagonTestCase extends PlexusTestCase {
      * @throws Exception
      * @since 1.0-beta-2
      */
+    @Test
     public void testWagonPutDirectoryDeepDestination() throws Exception {
         setupWagonTestingFixtures();
 
@@ -438,6 +486,7 @@ public abstract class WagonTestCase extends PlexusTestCase {
      * @throws Exception
      * @since 1.0-beta-1
      */
+    @Test
     public void testWagonPutDirectoryWhenDirectoryAlreadyExists() throws Exception {
 
         final String dirName = "directory-copy-existing";
@@ -488,6 +537,7 @@ public abstract class WagonTestCase extends PlexusTestCase {
      * @throws Exception
      * @since 1.0-beta-1
      */
+    @Test
     public void testWagonPutDirectoryForDot() throws Exception {
         final String resourceToCreate = "test-resource-1.txt";
 
@@ -579,6 +629,7 @@ public abstract class WagonTestCase extends PlexusTestCase {
         Files.write(dir.toPath().toAbsolutePath(), child.getBytes());
     }
 
+    @Test
     public void testFailedGet() throws Exception {
         setupWagonTestingFixtures();
 
@@ -611,6 +662,7 @@ public abstract class WagonTestCase extends PlexusTestCase {
         }
     }
 
+    @Test
     public void testFailedGetIfNewer() throws Exception {
         if (supportsGetIfNewer()) {
             setupWagonTestingFixtures();
@@ -643,6 +695,7 @@ public abstract class WagonTestCase extends PlexusTestCase {
      * @throws Exception
      * @since 1.0-beta-2
      */
+    @Test
     public void testWagonGetFileList() throws Exception {
         setupWagonTestingFixtures();
 
@@ -664,19 +717,19 @@ public abstract class WagonTestCase extends PlexusTestCase {
 
         try {
             List<String> list = wagon.getFileList(dirName);
-            assertNotNull("file list should not be null.", list);
+            assertNotNull(list, "file list should not be null.");
             assertTrue(
-                    "file list should contain more items (actually contains '" + list + "').",
-                    list.size() >= filenames.length);
+                    list.size() >= filenames.length,
+                    "file list should contain more items (actually contains '" + list + "').");
 
             for (String filename : filenames) {
-                assertTrue("Filename '" + filename + "' should be in list.", list.contains(filename));
+                assertTrue(list.contains(filename), "Filename '" + filename + "' should be in list.");
             }
 
             // WAGON-250
             list = wagon.getFileList("");
-            assertNotNull("file list should not be null.", list);
-            assertFalse("file list should contain items (actually contains '" + list + "').", list.isEmpty());
+            assertNotNull(list, "file list should not be null.");
+            assertFalse(list.isEmpty(), "file list should contain items (actually contains '" + list + "').");
             assertTrue(list.contains("file-list/"));
             assertFalse(list.contains("file-list"));
             assertFalse(list.contains("."));
@@ -685,7 +738,7 @@ public abstract class WagonTestCase extends PlexusTestCase {
             assertFalse(list.contains("../"));
         } catch (UnsupportedOperationException e) {
             // Some providers don't support this
-            Assume.assumeFalse(false);
+            Assumptions.assumeFalse(false);
         } finally {
             wagon.disconnect();
 
@@ -699,6 +752,7 @@ public abstract class WagonTestCase extends PlexusTestCase {
      * @throws Exception
      * @since 1.0-beta-2
      */
+    @Test
     public void testWagonGetFileListWhenDirectoryDoesNotExist() throws Exception {
         setupWagonTestingFixtures();
 
@@ -717,7 +771,7 @@ public abstract class WagonTestCase extends PlexusTestCase {
             // expected
         } catch (UnsupportedOperationException e) {
             // Some providers don't support this
-            Assume.assumeFalse(false);
+            Assumptions.assumeFalse(false);
         } finally {
             wagon.disconnect();
 
@@ -731,6 +785,7 @@ public abstract class WagonTestCase extends PlexusTestCase {
      * @throws Exception
      * @since 1.0-beta-2
      */
+    @Test
     public void testWagonResourceExists() throws Exception {
         setupWagonTestingFixtures();
 
@@ -742,7 +797,7 @@ public abstract class WagonTestCase extends PlexusTestCase {
 
         wagon.connect(testRepository, getAuthInfo());
 
-        assertTrue(sourceFile.getName() + " does not exist", wagon.resourceExists(sourceFile.getName()));
+        assertTrue(wagon.resourceExists(sourceFile.getName()), sourceFile.getName() + " does not exist");
 
         wagon.disconnect();
 
@@ -755,6 +810,7 @@ public abstract class WagonTestCase extends PlexusTestCase {
      * @throws Exception
      * @since 1.0-beta-2
      */
+    @Test
     public void testWagonResourceNotExists() throws Exception {
         setupWagonTestingFixtures();
 
@@ -924,17 +980,17 @@ public abstract class WagonTestCase extends PlexusTestCase {
 
         int expectedSize = putFile();
 
-        assertNotNull("check checksum is not null", checksumObserver.getActualChecksum());
+        assertNotNull(checksumObserver.getActualChecksum(), "check checksum is not null");
 
-        assertEquals("compare checksums", TEST_CKSUM, checksumObserver.getActualChecksum());
+        assertEquals(TEST_CKSUM, checksumObserver.getActualChecksum(), "compare checksums");
 
         checksumObserver = new ChecksumObserver();
 
         getFile(expectedSize);
 
-        assertNotNull("check checksum is not null", checksumObserver.getActualChecksum());
+        assertNotNull(checksumObserver.getActualChecksum(), "check checksum is not null");
 
-        assertEquals("compare checksums", TEST_CKSUM, checksumObserver.getActualChecksum());
+        assertEquals(TEST_CKSUM, checksumObserver.getActualChecksum(), "compare checksums");
 
         // Now compare the contents of the artifact that was placed in
         // the repository with the contents of the artifact that was

--- a/wagon-provider-test/src/main/java/org/apache/maven/wagon/http/HttpWagonTestCase.java
+++ b/wagon-provider-test/src/main/java/org/apache/maven/wagon/http/HttpWagonTestCase.java
@@ -80,8 +80,14 @@ import org.eclipse.jetty.servlet.ServletContextHandler;
 import org.eclipse.jetty.servlet.ServletHolder;
 import org.eclipse.jetty.util.security.Constraint;
 import org.eclipse.jetty.util.security.Password;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  *
@@ -143,6 +149,7 @@ public abstract class HttpWagonTestCase extends StreamingWagonTestCase {
         server.stop();
     }
 
+    @Test
     public void testHttpHeaders() throws Exception {
         Properties headers = new Properties();
         headers.setProperty("User-Agent", "Maven-Wagon/1.0");
@@ -171,6 +178,7 @@ public abstract class HttpWagonTestCase extends StreamingWagonTestCase {
     /**
      * test set of User-Agent as it's done by aether wagon connector with using setHttpHeaders
      */
+    @Test
     public void testHttpHeadersWithCommonMethods() throws Exception {
         Properties properties = new Properties();
         properties.setProperty("User-Agent", "Maven-Wagon/1.0");
@@ -198,6 +206,7 @@ public abstract class HttpWagonTestCase extends StreamingWagonTestCase {
         assertEquals("Maven-Wagon/1.0", handler.headers.get("User-Agent"));
     }
 
+    @Test
     public void testUserAgentHeaderIsPresentByDefault() throws Exception {
         StreamingWagon wagon = (StreamingWagon) getWagon();
         Server server = new Server();
@@ -211,9 +220,10 @@ public abstract class HttpWagonTestCase extends StreamingWagonTestCase {
         server.stop();
 
         assertNotNull(
-                "default User-Agent header of wagon provider should be present", handler.headers.get("User-Agent"));
+                handler.headers.get("User-Agent"), "default User-Agent header of wagon provider should be present");
     }
 
+    @Test
     public void testUserAgentHeaderIsPresentOnlyOnceIfSetMultipleTimes() throws Exception {
         StreamingWagon wagon = (StreamingWagon) getWagon();
 
@@ -255,6 +265,7 @@ public abstract class HttpWagonTestCase extends StreamingWagonTestCase {
         return getProtocol() + "://localhost:" + localPort;
     }
 
+    @Test
     public void testGetForbidden() throws Exception {
         try {
             runTestGet(HttpServletResponse.SC_FORBIDDEN);
@@ -264,6 +275,7 @@ public abstract class HttpWagonTestCase extends StreamingWagonTestCase {
         }
     }
 
+    @Test
     public void testGet404() throws Exception {
         try {
             runTestGet(HttpServletResponse.SC_NOT_FOUND);
@@ -273,6 +285,7 @@ public abstract class HttpWagonTestCase extends StreamingWagonTestCase {
         }
     }
 
+    @Test
     public void testGet500() throws Exception {
         try {
             runTestGet(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
@@ -307,6 +320,7 @@ public abstract class HttpWagonTestCase extends StreamingWagonTestCase {
         }
     }
 
+    @Test
     public void testResourceExistsForbidden() throws Exception {
         try {
             runTestResourceExists(HttpServletResponse.SC_FORBIDDEN);
@@ -316,6 +330,7 @@ public abstract class HttpWagonTestCase extends StreamingWagonTestCase {
         }
     }
 
+    @Test
     public void testResourceExists404() throws Exception {
         try {
             assertFalse(runTestResourceExists(HttpServletResponse.SC_NOT_FOUND));
@@ -324,6 +339,7 @@ public abstract class HttpWagonTestCase extends StreamingWagonTestCase {
         }
     }
 
+    @Test
     public void testResourceExists500() throws Exception {
         try {
             runTestResourceExists(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
@@ -333,6 +349,7 @@ public abstract class HttpWagonTestCase extends StreamingWagonTestCase {
         }
     }
 
+    @Test
     public void testResourceExists429() throws Exception {
         try {
 
@@ -400,6 +417,7 @@ public abstract class HttpWagonTestCase extends StreamingWagonTestCase {
         return getTestFile("target/test-output/http-repository");
     }
 
+    @Test
     public void testGzipGet() throws Exception {
         Server server = new Server();
 
@@ -443,6 +461,7 @@ public abstract class HttpWagonTestCase extends StreamingWagonTestCase {
         }
     }
 
+    @Test
     public void testProxiedRequest() throws Exception {
         ProxyInfo proxyInfo = createProxyInfo();
         TestHeaderHandler handler = new TestHeaderHandler();
@@ -450,6 +469,7 @@ public abstract class HttpWagonTestCase extends StreamingWagonTestCase {
         runTestProxiedRequest(proxyInfo, handler);
     }
 
+    @Test
     public void testProxiedRequestWithAuthentication() throws Exception {
         ProxyInfo proxyInfo = createProxyInfo();
         proxyInfo.setUserName("user");
@@ -470,6 +490,7 @@ public abstract class HttpWagonTestCase extends StreamingWagonTestCase {
         }
     }
 
+    @Test
     public void testProxiedRequestWithAuthenticationWithProvider() throws Exception {
         final ProxyInfo proxyInfo = createProxyInfo();
         proxyInfo.setUserName("user");
@@ -495,6 +516,7 @@ public abstract class HttpWagonTestCase extends StreamingWagonTestCase {
         }
     }
 
+    @Test
     public void testRedirectGetToStream() throws Exception {
         StreamingWagon wagon = (StreamingWagon) getWagon();
 
@@ -538,7 +560,7 @@ public abstract class HttpWagonTestCase extends StreamingWagonTestCase {
             fileOutputStream.flush();
             fileOutputStream.close();
             String found = new String(Files.readAllBytes(tmpResult.toPath()));
-            assertEquals("found:'" + found + "'", "Hello, World!", found);
+            assertEquals("Hello, World!", found, "found:'" + found + "'");
 
             checkHandlerResult(redirectHandler.handlerRequestResponses, HttpServletResponse.SC_SEE_OTHER);
             checkHandlerResult(handler.handlerRequestResponses, HttpServletResponse.SC_OK);
@@ -552,6 +574,7 @@ public abstract class HttpWagonTestCase extends StreamingWagonTestCase {
         }
     }
 
+    @Test
     public void testRedirectGet() throws Exception {
         StreamingWagon wagon = (StreamingWagon) getWagon();
 
@@ -593,7 +616,7 @@ public abstract class HttpWagonTestCase extends StreamingWagonTestCase {
         try {
             wagon.get("resource", tmpResult);
             String found = new String(Files.readAllBytes(tmpResult.toPath()));
-            assertEquals("found:'" + found + "'", "Hello, World!", found);
+            assertEquals("Hello, World!", found, "found:'" + found + "'");
 
             checkHandlerResult(redirectHandler.handlerRequestResponses, HttpServletResponse.SC_SEE_OTHER);
             checkHandlerResult(handler.handlerRequestResponses, HttpServletResponse.SC_OK);
@@ -607,6 +630,7 @@ public abstract class HttpWagonTestCase extends StreamingWagonTestCase {
         }
     }
 
+    @Test
     public void testRedirectPutFromStreamWithFullUrl() throws Exception {
         Server realServer = new Server();
 
@@ -684,6 +708,7 @@ public abstract class HttpWagonTestCase extends StreamingWagonTestCase {
         checkHandlerResult(putHandler.handlerRequestResponses, HttpServletResponse.SC_CREATED);
     }
 
+    @Test
     public void testRedirectPutFromStreamRelativeUrl() throws Exception {
         Server realServer = new Server();
         addConnector(realServer);
@@ -763,6 +788,7 @@ public abstract class HttpWagonTestCase extends StreamingWagonTestCase {
         }
     }
 
+    @Test
     public void testRedirectPutFileWithFullUrl() throws Exception {
         Server realServer = new Server();
 
@@ -833,6 +859,7 @@ public abstract class HttpWagonTestCase extends StreamingWagonTestCase {
         }
     }
 
+    @Test
     public void testRedirectPutFileRelativeUrl() throws Exception {
         Server realServer = new Server();
         addConnector(realServer);
@@ -888,6 +915,7 @@ public abstract class HttpWagonTestCase extends StreamingWagonTestCase {
         }
     }
 
+    @Test
     public void testRedirectPutFailureNonRepeatableStream() throws Exception {
         File repositoryDirectory = getRepositoryDirectory();
         FileUtils.deleteDirectory(repositoryDirectory);
@@ -1094,6 +1122,7 @@ public abstract class HttpWagonTestCase extends StreamingWagonTestCase {
         return proxyInfo;
     }
 
+    @Test
     public void testSecuredGetUnauthorized() throws Exception {
         try {
             runTestSecuredGet(null);
@@ -1103,6 +1132,7 @@ public abstract class HttpWagonTestCase extends StreamingWagonTestCase {
         }
     }
 
+    @Test
     public void testSecuredGetWrongPassword() throws Exception {
         try {
             AuthenticationInfo authInfo = new AuthenticationInfo();
@@ -1115,6 +1145,7 @@ public abstract class HttpWagonTestCase extends StreamingWagonTestCase {
         }
     }
 
+    @Test
     public void testSecuredGet() throws Exception {
         AuthenticationInfo authInfo = new AuthenticationInfo();
         authInfo.setUserName("user");
@@ -1166,6 +1197,7 @@ public abstract class HttpWagonTestCase extends StreamingWagonTestCase {
         }
     }
 
+    @Test
     public void testSecuredGetToStream() throws Exception {
         AuthenticationInfo authInfo = new AuthenticationInfo();
         authInfo.setUserName("user");
@@ -1215,6 +1247,7 @@ public abstract class HttpWagonTestCase extends StreamingWagonTestCase {
         }
     }
 
+    @Test
     public void testSecuredResourceExistsUnauthorized() throws Exception {
         try {
             runTestSecuredResourceExists(null);
@@ -1224,6 +1257,7 @@ public abstract class HttpWagonTestCase extends StreamingWagonTestCase {
         }
     }
 
+    @Test
     public void testSecuredResourceExistsWrongPassword() throws Exception {
         try {
             AuthenticationInfo authInfo = new AuthenticationInfo();
@@ -1235,6 +1269,7 @@ public abstract class HttpWagonTestCase extends StreamingWagonTestCase {
         }
     }
 
+    @Test
     public void testSecuredResourceExists() throws Exception {
         AuthenticationInfo authInfo = new AuthenticationInfo();
         authInfo.setUserName("user");
@@ -1337,6 +1372,7 @@ public abstract class HttpWagonTestCase extends StreamingWagonTestCase {
         return content;
     }
 
+    @Test
     public void testPutForbidden() throws Exception {
         try {
             runTestPut(HttpServletResponse.SC_FORBIDDEN);
@@ -1346,6 +1382,7 @@ public abstract class HttpWagonTestCase extends StreamingWagonTestCase {
         }
     }
 
+    @Test
     public void testPut404() throws Exception {
         try {
             runTestPut(HttpServletResponse.SC_NOT_FOUND);
@@ -1355,6 +1392,7 @@ public abstract class HttpWagonTestCase extends StreamingWagonTestCase {
         }
     }
 
+    @Test
     public void testPut500() throws Exception {
         try {
             runTestPut(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
@@ -1364,6 +1402,7 @@ public abstract class HttpWagonTestCase extends StreamingWagonTestCase {
         }
     }
 
+    @Test
     public void testPut429() throws Exception {
 
         try {
@@ -1444,6 +1483,7 @@ public abstract class HttpWagonTestCase extends StreamingWagonTestCase {
         }
     }
 
+    @Test
     public void testSecuredPutUnauthorized() throws Exception {
         try {
             runTestSecuredPut(null);
@@ -1453,6 +1493,7 @@ public abstract class HttpWagonTestCase extends StreamingWagonTestCase {
         }
     }
 
+    @Test
     public void testSecuredPutWrongPassword() throws Exception {
         try {
             AuthenticationInfo authInfo = new AuthenticationInfo();
@@ -1465,6 +1506,7 @@ public abstract class HttpWagonTestCase extends StreamingWagonTestCase {
         }
     }
 
+    @Test
     public void testSecuredPut() throws Exception {
         AuthenticationInfo authInfo = new AuthenticationInfo();
         authInfo.setUserName("user");
@@ -1520,6 +1562,7 @@ public abstract class HttpWagonTestCase extends StreamingWagonTestCase {
         testPreemptiveAuthenticationPut(sh, supportPreemptiveAuthenticationPut());
     }
 
+    @Test
     public void testNonSecuredPutFromStream() throws Exception {
         AuthenticationInfo authInfo = new AuthenticationInfo();
         authInfo.setUserName("user");
@@ -1527,6 +1570,7 @@ public abstract class HttpWagonTestCase extends StreamingWagonTestCase {
         runTestSecuredPutFromStream(authInfo, 1, false);
     }
 
+    @Test
     public void testSecuredPutFromStream() throws Exception {
         AuthenticationInfo authInfo = new AuthenticationInfo();
         authInfo.setUserName("user");
@@ -1602,23 +1646,23 @@ public abstract class HttpWagonTestCase extends StreamingWagonTestCase {
 
     protected abstract boolean supportProxyPreemptiveAuthentication();
 
-    protected void testPreemptiveAuthenticationGet(TestSecurityHandler sh, boolean preemptive) {
+    public void testPreemptiveAuthenticationGet(TestSecurityHandler sh, boolean preemptive) {
         testPreemptiveAuthentication(sh, preemptive, HttpServletResponse.SC_OK);
     }
 
-    protected void testPreemptiveAuthenticationPut(TestSecurityHandler sh, boolean preemptive) {
+    public void testPreemptiveAuthenticationPut(TestSecurityHandler sh, boolean preemptive) {
         testPreemptiveAuthentication(sh, preemptive, HttpServletResponse.SC_CREATED);
     }
 
-    protected void testPreemptiveAuthentication(TestSecurityHandler sh, boolean preemptive, int statusCode) {
+    public void testPreemptiveAuthentication(TestSecurityHandler sh, boolean preemptive, int statusCode) {
 
         if (preemptive) {
             assertEquals(
-                    "not 1 security handler use " + sh.handlerRequestResponses, 1, sh.handlerRequestResponses.size());
+                    1, sh.handlerRequestResponses.size(), "not 1 security handler use " + sh.handlerRequestResponses);
             assertEquals(statusCode, sh.handlerRequestResponses.get(0).responseCode);
         } else {
             assertEquals(
-                    "not 2 security handler use " + sh.handlerRequestResponses, 2, sh.handlerRequestResponses.size());
+                    2, sh.handlerRequestResponses.size(), "not 2 security handler use " + sh.handlerRequestResponses);
             assertEquals(HttpServletResponse.SC_UNAUTHORIZED, sh.handlerRequestResponses.get(0).responseCode);
             assertEquals(statusCode, sh.handlerRequestResponses.get(1).responseCode);
         }
@@ -1872,7 +1916,7 @@ public abstract class HttpWagonTestCase extends StreamingWagonTestCase {
         // TODO: handle AuthenticationException for Wagon.connect() calls
         assertNotNull(e);
         try {
-            assertTrue("only verify instances of WagonException", e instanceof WagonException);
+            assertTrue(e instanceof WagonException, "only verify instances of WagonException");
 
             String reasonPhrase;
             String assertMessageForBadMessage = "exception message not described properly";
@@ -1880,70 +1924,70 @@ public abstract class HttpWagonTestCase extends StreamingWagonTestCase {
                 case HttpServletResponse.SC_NOT_FOUND:
                     // TODO: add test for 410: Gone?
                     assertTrue(
-                            "404 not found response should throw ResourceDoesNotExistException",
-                            e instanceof ResourceDoesNotExistException);
+                            e instanceof ResourceDoesNotExistException,
+                            "404 not found response should throw ResourceDoesNotExistException");
                     reasonPhrase = (forReasonPhrase == null || forReasonPhrase.isEmpty())
                             ? " Not Found"
                             : (" " + forReasonPhrase);
                     assertEquals(
-                            assertMessageForBadMessage,
                             "resource missing at " + forUrl + ", status: 404" + reasonPhrase,
-                            e.getMessage());
+                            e.getMessage(),
+                            assertMessageForBadMessage);
                     break;
 
                 case HttpServletResponse.SC_UNAUTHORIZED:
                     // FIXME assumes Wagon.get()/put() returning 401 instead of Wagon.connect()
                     assertTrue(
+                            e instanceof AuthorizationException,
                             "401 Unauthorized should throw AuthorizationException since "
                                     + " AuthenticationException is not explicitly declared as thrown from wagon "
-                                    + "methods",
-                            e instanceof AuthorizationException);
+                                    + "methods");
                     reasonPhrase = (forReasonPhrase == null || forReasonPhrase.isEmpty())
                             ? " Unauthorized"
                             : (" " + forReasonPhrase);
                     assertEquals(
-                            assertMessageForBadMessage,
                             "authentication failed for " + forUrl + ", status: 401" + reasonPhrase,
-                            e.getMessage());
+                            e.getMessage(),
+                            assertMessageForBadMessage);
                     break;
 
                 case HttpServletResponse.SC_PROXY_AUTHENTICATION_REQUIRED:
                     assertTrue(
-                            "407 Proxy authentication required should throw AuthorizationException",
-                            e instanceof AuthorizationException);
+                            e instanceof AuthorizationException,
+                            "407 Proxy authentication required should throw AuthorizationException");
                     reasonPhrase = (forReasonPhrase == null || forReasonPhrase.isEmpty())
                             ? " Proxy Authentication Required"
                             : (" " + forReasonPhrase);
                     assertEquals(
-                            assertMessageForBadMessage,
                             "proxy authentication failed for " + forUrl + ", status: 407" + reasonPhrase,
-                            e.getMessage());
+                            e.getMessage(),
+                            assertMessageForBadMessage);
                     break;
 
                 case HttpServletResponse.SC_FORBIDDEN:
                     assertTrue(
-                            "403 Forbidden should throw AuthorizationException", e instanceof AuthorizationException);
+                            e instanceof AuthorizationException, "403 Forbidden should throw AuthorizationException");
                     reasonPhrase = (forReasonPhrase == null || forReasonPhrase.isEmpty())
                             ? " Forbidden"
                             : (" " + forReasonPhrase);
                     assertEquals(
-                            assertMessageForBadMessage,
                             "authorization failed for " + forUrl + ", status: 403" + reasonPhrase,
-                            e.getMessage());
+                            e.getMessage(),
+                            assertMessageForBadMessage);
                     break;
 
                 default:
                     assertTrue(
-                            "transfer failures should at least be wrapped in a TransferFailedException",
-                            e instanceof TransferFailedException);
+                            e instanceof TransferFailedException,
+                            "transfer failures should at least be wrapped in a TransferFailedException");
                     assertTrue(
-                            "expected status code for transfer failures should be >= 400",
-                            forStatusCode >= HttpServletResponse.SC_BAD_REQUEST);
+                            forStatusCode >= HttpServletResponse.SC_BAD_REQUEST,
+                            "expected status code for transfer failures should be >= 400");
                     reasonPhrase = forReasonPhrase == null ? "" : " " + forReasonPhrase;
                     assertEquals(
-                            assertMessageForBadMessage,
                             "transfer failed for " + forUrl + ", status: " + forStatusCode + reasonPhrase,
-                            e.getMessage());
+                            e.getMessage(),
+                            assertMessageForBadMessage);
                     break;
             }
         } catch (AssertionError assertionError) {

--- a/wagon-providers/pom.xml
+++ b/wagon-providers/pom.xml
@@ -78,6 +78,12 @@ under the License.
       <groupId>org.apache.maven.wagon</groupId>
       <artifactId>wagon-provider-test</artifactId>
       <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>junit</groupId>
+          <artifactId>junit</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
   </dependencies>
 </project>

--- a/wagon-providers/wagon-file/src/test/java/org/apache/maven/wagon/providers/file/FileWagonTest.java
+++ b/wagon-providers/wagon-file/src/test/java/org/apache/maven/wagon/providers/file/FileWagonTest.java
@@ -28,6 +28,10 @@ import org.apache.maven.wagon.Wagon;
 import org.apache.maven.wagon.authentication.AuthenticationException;
 import org.apache.maven.wagon.repository.Repository;
 import org.apache.maven.wagon.resource.Resource;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * @author <a href="michal.maczka@dimatics.com">Michal Maczka</a>
@@ -51,6 +55,7 @@ public class FileWagonTest extends StreamingWagonTestCase {
      * @throws ConnectionException
      * @throws AuthenticationException
      */
+    @Test
     public void testNullFileWagon() throws ConnectionException, AuthenticationException {
         Wagon wagon = new FileWagon();
         Repository repository = new Repository();
@@ -62,6 +67,7 @@ public class FileWagonTest extends StreamingWagonTestCase {
         return new File(repository.getBasedir(), resource.getName()).lastModified();
     }
 
+    @Test
     public void testResourceExists() throws Exception {
         String url = new File(getBasedir()).toPath().toUri().toASCIIString();
 

--- a/wagon-providers/wagon-ftp/src/test/java/org/apache/maven/wagon/providers/ftp/FtpWagonTest.java
+++ b/wagon-providers/wagon-ftp/src/test/java/org/apache/maven/wagon/providers/ftp/FtpWagonTest.java
@@ -39,6 +39,11 @@ import org.apache.maven.wagon.authentication.AuthenticationException;
 import org.apache.maven.wagon.authentication.AuthenticationInfo;
 import org.apache.maven.wagon.repository.Repository;
 import org.apache.maven.wagon.resource.Resource;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * @author <a href="michal.maczka@dimatics.com">Michal Maczka</a>
@@ -138,6 +143,7 @@ public class FtpWagonTest extends StreamingWagonTestCase {
         return getTestFile("target/test-output/local-repository");
     }
 
+    @Test
     public void testNoPassword() throws Exception {
         AuthenticationInfo authenticationInfo = new AuthenticationInfo();
         authenticationInfo.setUserName("me");
@@ -149,6 +155,7 @@ public class FtpWagonTest extends StreamingWagonTestCase {
         }
     }
 
+    @Test
     public void testDefaultUserName() throws Exception {
         AuthenticationInfo authenticationInfo = new AuthenticationInfo();
         authenticationInfo.setPassword("secret");
@@ -163,6 +170,7 @@ public class FtpWagonTest extends StreamingWagonTestCase {
     /**
      * This is a unit test to show WAGON-265
      */
+    @Test
     public void testPutDirectoryCreation() throws Exception {
         setupWagonTestingFixtures();
 

--- a/wagon-providers/wagon-http-lightweight/pom.xml
+++ b/wagon-providers/wagon-http-lightweight/pom.xml
@@ -31,6 +31,12 @@ under the License.
   <description>Wagon provider that gets and puts artifacts through http using standard Java library</description>
 
   <dependencies>
+    <!-- TckTest aggregates the TCK suites, now through the JUnit Platform -->
+    <dependency>
+      <groupId>org.junit.platform</groupId>
+      <artifactId>junit-platform-suite</artifactId>
+      <scope>test</scope>
+    </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>wagon-http-shared</artifactId>
@@ -43,6 +49,12 @@ under the License.
       <artifactId>wagon-tck-http</artifactId>
       <version>${project.version}</version>
       <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>junit</groupId>
+          <artifactId>junit</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.codehaus.plexus</groupId>
@@ -53,13 +65,13 @@ under the License.
       <artifactId>slf4j-api</artifactId>
     </dependency>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
+      <groupId>org.eclipse.jetty.aggregate</groupId>
+      <artifactId>jetty-all</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.eclipse.jetty.aggregate</groupId>
-      <artifactId>jetty-all</artifactId>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/wagon-providers/wagon-http-lightweight/src/test/java/org/apache/maven/wagon/providers/http/LightweightHttpWagonTest.java
+++ b/wagon-providers/wagon-http-lightweight/src/test/java/org/apache/maven/wagon/providers/http/LightweightHttpWagonTest.java
@@ -31,6 +31,10 @@ import org.apache.maven.wagon.WagonException;
 import org.apache.maven.wagon.authorization.AuthorizationException;
 import org.apache.maven.wagon.http.HttpWagonTestCase;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 /**
  * @author <a href="michal.maczka@dimatics.com">Michal Maczka</a>
  *
@@ -72,89 +76,89 @@ public class LightweightHttpWagonTest extends HttpWagonTestCase {
 
         assertNotNull(e);
         try {
-            assertTrue("only verify instances of WagonException", e instanceof WagonException);
+            assertTrue(e instanceof WagonException, "only verify instances of WagonException");
 
             String assertMessageForBadMessage = "exception message not described properly: ";
             switch (forStatusCode) {
                 case HttpServletResponse.SC_GONE:
                 case HttpServletResponse.SC_NOT_FOUND:
                     assertTrue(
-                            "404 or 410 should throw ResourceDoesNotExistException",
-                            e instanceof ResourceDoesNotExistException);
+                            e instanceof ResourceDoesNotExistException,
+                            "404 or 410 should throw ResourceDoesNotExistException");
 
                     if (e.getCause() != null) {
                         assertTrue(
-                                "ResourceDoesNotExistException should have the expected cause",
-                                e.getCause() instanceof FileNotFoundException);
+                                e.getCause() instanceof FileNotFoundException,
+                                "ResourceDoesNotExistException should have the expected cause");
                         // the status code and reason phrase cannot always be learned due to implementation limitations
                         // which means the message may not include them
-                        assertEquals(assertMessageForBadMessage, "resource missing at " + forUrl, e.getMessage());
+                        assertEquals("resource missing at " + forUrl, e.getMessage(), assertMessageForBadMessage);
                     } else {
                         assertEquals(
-                                assertMessageForBadMessage,
                                 "resource missing at " + forUrl + ", status: " + forStatusCode + " " + forReasonPhrase,
-                                e.getMessage());
+                                e.getMessage(),
+                                assertMessageForBadMessage);
                     }
 
                     break;
 
                 case HttpServletResponse.SC_FORBIDDEN:
-                    assertTrue("403 Forbidden throws AuthorizationException", e instanceof AuthorizationException);
+                    assertTrue(e instanceof AuthorizationException, "403 Forbidden throws AuthorizationException");
 
                     assertEquals(
-                            assertMessageForBadMessage,
                             "authorization failed for " + forUrl + ", status: 403"
                                     + ((forReasonPhrase == null || forReasonPhrase.isEmpty())
                                             ? " Forbidden"
                                             : (" " + forReasonPhrase)),
-                            e.getMessage());
+                            e.getMessage(),
+                            assertMessageForBadMessage);
                     break;
 
                 case HttpServletResponse.SC_UNAUTHORIZED:
-                    assertTrue("401 Unauthorized throws AuthorizationException", e instanceof AuthorizationException);
+                    assertTrue(e instanceof AuthorizationException, "401 Unauthorized throws AuthorizationException");
 
                     assertEquals(
-                            assertMessageForBadMessage,
                             "authentication failed for " + forUrl + ", status: 401"
                                     + ((forReasonPhrase == null || forReasonPhrase.isEmpty())
                                             ? " Unauthorized"
                                             : (" " + forReasonPhrase)),
-                            e.getMessage());
+                            e.getMessage(),
+                            assertMessageForBadMessage);
                     break;
 
                 default:
                     assertTrue(
-                            "general exception must be TransferFailedException", e instanceof TransferFailedException);
+                            e instanceof TransferFailedException, "general exception must be TransferFailedException");
                     assertTrue(
+                            forStatusCode >= HttpServletResponse.SC_BAD_REQUEST,
                             "expected status code for transfer failures should be >= 400, but none of "
-                                    + " the already handled codes",
-                            forStatusCode >= HttpServletResponse.SC_BAD_REQUEST);
+                                    + " the already handled codes");
 
                     if (e.getCause() != null) {
                         assertTrue(
-                                "TransferFailedException should have the original cause for diagnosis",
-                                e.getCause() instanceof IOException);
+                                e.getCause() instanceof IOException,
+                                "TransferFailedException should have the original cause for diagnosis");
                     }
 
                     // the status code and reason phrase cannot always be learned due to implementation limitations
                     // so the message may not include them, but the implementation should use a consistent format
                     assertTrue(
-                            "message should always include url",
-                            e.getMessage().startsWith("transfer failed for " + forUrl));
+                            e.getMessage().startsWith("transfer failed for " + forUrl),
+                            "message should always include url");
 
                     if (e.getMessage().length() > ("transfer failed for " + forUrl).length()) {
                         assertTrue(
-                                "message should include url and status code",
                                 e.getMessage()
-                                        .startsWith("transfer failed for " + forUrl + ", status: " + forStatusCode));
+                                        .startsWith("transfer failed for " + forUrl + ", status: " + forStatusCode),
+                                "message should include url and status code");
                     }
 
                     if (e.getMessage().length()
                             > ("transfer failed for " + forUrl + ", status: " + forStatusCode).length()) {
                         assertEquals(
-                                "message should include url and status code and reason phrase",
                                 "transfer failed for " + forUrl + ", status: " + forStatusCode + " " + forReasonPhrase,
-                                e.getMessage());
+                                e.getMessage(),
+                                "message should include url and status code and reason phrase");
                     }
 
                     break;

--- a/wagon-providers/wagon-http-lightweight/src/test/java/org/apache/maven/wagon/providers/http/TckTest.java
+++ b/wagon-providers/wagon-http-lightweight/src/test/java/org/apache/maven/wagon/providers/http/TckTest.java
@@ -20,14 +20,14 @@ package org.apache.maven.wagon.providers.http;
 
 import org.apache.maven.wagon.tck.http.GetWagonTests;
 import org.apache.maven.wagon.tck.http.HttpsGetWagonTests;
-import org.junit.runner.RunWith;
-import org.junit.runners.Suite;
+import org.junit.platform.suite.api.SelectClasses;
+import org.junit.platform.suite.api.Suite;
 
 /**
  * This test will runn the TCK suite on wagon-http-lightweight
  */
-@RunWith(Suite.class)
-@Suite.SuiteClasses({GetWagonTests.class, HttpsGetWagonTests.class})
+@Suite
+@SelectClasses({GetWagonTests.class, HttpsGetWagonTests.class})
 public class TckTest {
     // no op
 }

--- a/wagon-providers/wagon-http/pom.xml
+++ b/wagon-providers/wagon-http/pom.xml
@@ -31,6 +31,12 @@ under the License.
   <description>Wagon provider that gets and puts artifacts through HTTP(S) using Apache HttpClient-4.x.</description>
 
   <dependencies>
+    <!-- TckTest aggregates the TCK suites, now through the JUnit Platform -->
+    <dependency>
+      <groupId>org.junit.platform</groupId>
+      <artifactId>junit-platform-suite</artifactId>
+      <scope>test</scope>
+    </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>wagon-http-shared</artifactId>
@@ -74,17 +80,6 @@ under the License.
       <artifactId>junit-jupiter</artifactId>
       <scope>test</scope>
     </dependency>
-    <!-- HttpWagonTest and its subclasses inherit JUnit 4 tests from the published HttpWagonTestCase -->
-    <dependency>
-      <groupId>org.junit.vintage</groupId>
-      <artifactId>junit-vintage-engine</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <scope>test</scope>
-    </dependency>
     <dependency>
       <groupId>org.eclipse.jetty.aggregate</groupId>
       <artifactId>jetty-all</artifactId>
@@ -113,6 +108,12 @@ under the License.
       <artifactId>wagon-tck-http</artifactId>
       <version>${project.version}</version>
       <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>junit</groupId>
+          <artifactId>junit</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
   </dependencies>

--- a/wagon-providers/wagon-http/src/test/java/org/apache/maven/wagon/providers/http/TckTest.java
+++ b/wagon-providers/wagon-http/src/test/java/org/apache/maven/wagon/providers/http/TckTest.java
@@ -20,14 +20,14 @@ package org.apache.maven.wagon.providers.http;
 
 import org.apache.maven.wagon.tck.http.GetWagonTests;
 import org.apache.maven.wagon.tck.http.HttpsGetWagonTests;
-import org.junit.runner.RunWith;
-import org.junit.runners.Suite;
+import org.junit.platform.suite.api.SelectClasses;
+import org.junit.platform.suite.api.Suite;
 
 /**
  * This test will run the TCK suite on wagon-http-lightweight
  */
-@RunWith(Suite.class)
-@Suite.SuiteClasses({GetWagonTests.class, HttpsGetWagonTests.class})
+@Suite
+@SelectClasses({GetWagonTests.class, HttpsGetWagonTests.class})
 public class TckTest {
     // no op
 }

--- a/wagon-providers/wagon-scm/src/test/java/org/apache/maven/wagon/providers/scm/AbstractScmCvsWagonTest.java
+++ b/wagon-providers/wagon-scm/src/test/java/org/apache/maven/wagon/providers/scm/AbstractScmCvsWagonTest.java
@@ -22,6 +22,7 @@ import java.io.File;
 import java.io.IOException;
 
 import org.codehaus.plexus.util.FileUtils;
+import org.junit.jupiter.api.BeforeEach;
 
 /**
  * Test for ScmWagon using CVS as underlying SCM
@@ -32,8 +33,8 @@ import org.codehaus.plexus.util.FileUtils;
 public abstract class AbstractScmCvsWagonTest extends AbstractScmWagonTest {
     private String repository;
 
-    @Override
-    protected void setUp() throws Exception {
+    @BeforeEach
+    public void setUp() throws Exception {
         super.setUp();
 
         File origRepo = getTestFile("target/test-classes/test-repo-cvs");

--- a/wagon-providers/wagon-scm/src/test/java/org/apache/maven/wagon/providers/scm/AbstractScmGitWagonTest.java
+++ b/wagon-providers/wagon-scm/src/test/java/org/apache/maven/wagon/providers/scm/AbstractScmGitWagonTest.java
@@ -21,6 +21,7 @@ package org.apache.maven.wagon.providers.scm;
 import java.io.File;
 
 import org.codehaus.plexus.util.FileUtils;
+import org.junit.jupiter.api.BeforeEach;
 
 /**
  * Test for ScmWagon using Git as underlying SCM
@@ -28,7 +29,8 @@ import org.codehaus.plexus.util.FileUtils;
 public abstract class AbstractScmGitWagonTest extends AbstractScmWagonTest {
     private String repository;
 
-    protected void setUp() throws Exception {
+    @BeforeEach
+    public void setUp() throws Exception {
         super.setUp();
 
         // copy the repo for the test

--- a/wagon-providers/wagon-scm/src/test/java/org/apache/maven/wagon/providers/scm/AbstractScmSvnWagonTest.java
+++ b/wagon-providers/wagon-scm/src/test/java/org/apache/maven/wagon/providers/scm/AbstractScmSvnWagonTest.java
@@ -21,6 +21,7 @@ package org.apache.maven.wagon.providers.scm;
 import java.io.File;
 
 import org.codehaus.plexus.util.FileUtils;
+import org.junit.jupiter.api.BeforeEach;
 
 /**
  * Test for ScmWagon using SVN as underlying SCM
@@ -31,7 +32,8 @@ import org.codehaus.plexus.util.FileUtils;
 public abstract class AbstractScmSvnWagonTest extends AbstractScmWagonTest {
     private String repository;
 
-    protected void setUp() throws Exception {
+    @BeforeEach
+    public void setUp() throws Exception {
         super.setUp();
 
         // copy the repo for the test

--- a/wagon-providers/wagon-scm/src/test/java/org/apache/maven/wagon/providers/scm/AbstractScmWagonTest.java
+++ b/wagon-providers/wagon-scm/src/test/java/org/apache/maven/wagon/providers/scm/AbstractScmWagonTest.java
@@ -38,6 +38,8 @@ import org.apache.maven.wagon.authorization.AuthorizationException;
 import org.apache.maven.wagon.repository.Repository;
 import org.apache.maven.wagon.resource.Resource;
 import org.codehaus.plexus.util.FileUtils;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test for {@link ScmWagon}. You need a subclass for each SCM provider you want to test.
@@ -47,7 +49,7 @@ import org.codehaus.plexus.util.FileUtils;
  */
 public abstract class AbstractScmWagonTest extends WagonTestCase {
 
-    @Override
+    @Test
     public void testWagonPutDirectory() throws Exception {
         super.testWagonPutDirectory();
         // repeat the test on a non-empty repo
@@ -60,7 +62,8 @@ public abstract class AbstractScmWagonTest extends WagonTestCase {
 
     private String providerClassName;
 
-    protected void setUp() throws Exception {
+    @BeforeEach
+    public void setUp() throws Exception {
         super.setUp();
 
         FileUtils.deleteDirectory(getCheckoutDirectory());

--- a/wagon-providers/wagon-scm/src/test/java/org/apache/maven/wagon/providers/scm/ScmCvsExeWagonTest.java
+++ b/wagon-providers/wagon-scm/src/test/java/org/apache/maven/wagon/providers/scm/ScmCvsExeWagonTest.java
@@ -20,6 +20,10 @@ package org.apache.maven.wagon.providers.scm;
 
 import org.apache.maven.scm.provider.ScmProvider;
 import org.apache.maven.scm.provider.cvslib.cvsexe.CvsExeScmProvider;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 /**
  * Test for ScmWagon using CVS Exe as underlying SCM
@@ -29,29 +33,27 @@ import org.apache.maven.scm.provider.cvslib.cvsexe.CvsExeScmProvider;
  */
 public class ScmCvsExeWagonTest extends AbstractScmCvsWagonTest {
 
-    @Override
-    protected void setUp() throws Exception {
+    @BeforeEach
+    public void setUp() throws Exception {
         assumeHaveCvsBinary();
-        if (!testSkipped) {
-            super.setUp();
-        }
+        super.setUp();
     }
 
     protected ScmProvider getScmProvider() {
         return new CvsExeScmProvider();
     }
 
-    @Override
+    @Test
     public void testWagonGetFileList() throws Exception {
         // cvs rls is rare
     }
 
-    @Override
+    @Test
     public void testWagonResourceExists() throws Exception {
         // cvs rls is rare
     }
 
-    @Override
+    @Test
     public void testWagonResourceNotExists() throws Exception {
         // cvs rls is rare
     }
@@ -61,12 +63,9 @@ public class ScmCvsExeWagonTest extends AbstractScmCvsWagonTest {
         return false;
     }
 
-    /** Optionally set the testSkipped flag */
+    /** Aborts the test when cvs is not installed. */
     protected void assumeHaveCvsBinary() {
-        if (!isSystemCmd(CVS_COMMAND_LINE)) {
-            testSkipped = true;
-            System.err.println("'" + CVS_COMMAND_LINE + "' is not a system command. Ignored " + getName() + ".");
-        }
+        assumeTrue(isSystemCmd(CVS_COMMAND_LINE), "'" + CVS_COMMAND_LINE + "' is not a system command");
     }
 
     /** 'cvs' command line */

--- a/wagon-providers/wagon-scm/src/test/java/org/apache/maven/wagon/providers/scm/ScmGitExeWagonTest.java
+++ b/wagon-providers/wagon-scm/src/test/java/org/apache/maven/wagon/providers/scm/ScmGitExeWagonTest.java
@@ -19,6 +19,7 @@
 package org.apache.maven.wagon.providers.scm;
 
 import org.apache.maven.scm.provider.ScmProvider;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test for ScmWagon using Git Exe as underlying SCM
@@ -29,7 +30,7 @@ public class ScmGitExeWagonTest extends AbstractScmGitWagonTest {
         return new UserSafeGitExeScmProvider();
     }
 
-    @Override
+    @Test
     public void testWagonGetFileList() throws Exception {
         // remote list unsupported
         // When a command is unsupported, SCM throws NoSuchCommandScmException.
@@ -39,17 +40,17 @@ public class ScmGitExeWagonTest extends AbstractScmGitWagonTest {
         // and skip the test using org.junit.Assume
     }
 
-    @Override
+    @Test
     public void testWagonGetFileListWhenDirectoryDoesNotExist() throws Exception {
         // remote list unsupported
     }
 
-    @Override
+    @Test
     public void testWagonResourceExists() throws Exception {
         // remote list unsupported
     }
 
-    @Override
+    @Test
     public void testWagonResourceNotExists() throws Exception {
         // remote list unsupported
     }

--- a/wagon-providers/wagon-ssh-common-test/pom.xml
+++ b/wagon-providers/wagon-ssh-common-test/pom.xml
@@ -33,6 +33,11 @@ under the License.
     <sshdVersion>2.19.0</sshdVersion>
   </properties>
   <dependencies>
+    <!-- KnownHostsProviderTestCase is published here and uses @PlexusTest -->
+    <dependency>
+      <groupId>org.codehaus.plexus</groupId>
+      <artifactId>plexus-testing</artifactId>
+    </dependency>
     <dependency>
       <groupId>org.eclipse.sisu</groupId>
       <artifactId>org.eclipse.sisu.plexus</artifactId>
@@ -55,6 +60,12 @@ under the License.
     <dependency>
       <groupId>org.apache.maven.wagon</groupId>
       <artifactId>wagon-provider-test</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>junit</groupId>
+          <artifactId>junit</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.apache.maven.wagon</groupId>

--- a/wagon-providers/wagon-ssh-common-test/src/main/java/org/apache/maven/wagon/providers/ssh/AbstractEmbeddedScpWagonTest.java
+++ b/wagon-providers/wagon-ssh-common-test/src/main/java/org/apache/maven/wagon/providers/ssh/AbstractEmbeddedScpWagonTest.java
@@ -25,6 +25,9 @@ import org.apache.maven.wagon.StreamingWagonTestCase;
 import org.apache.maven.wagon.authentication.AuthenticationInfo;
 import org.apache.maven.wagon.repository.Repository;
 import org.apache.maven.wagon.resource.Resource;
+import org.junit.jupiter.api.BeforeEach;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * @author <a href="michal.maczka@dimatics.com">Michal Maczka</a>
@@ -34,8 +37,8 @@ public abstract class AbstractEmbeddedScpWagonTest extends StreamingWagonTestCas
 
     SshServerEmbedded sshServer;
 
-    @Override
-    protected void setUp() throws Exception {
+    @BeforeEach
+    public void setUp() throws Exception {
         super.setUp();
 
         String sshKeyResource = "ssh-keys/id_rsa";

--- a/wagon-providers/wagon-ssh-common-test/src/main/java/org/apache/maven/wagon/providers/ssh/AbstractEmbeddedScpWagonWithKeyTest.java
+++ b/wagon-providers/wagon-ssh-common-test/src/main/java/org/apache/maven/wagon/providers/ssh/AbstractEmbeddedScpWagonWithKeyTest.java
@@ -28,6 +28,13 @@ import org.apache.maven.wagon.authentication.AuthenticationInfo;
 import org.apache.maven.wagon.repository.Repository;
 import org.apache.maven.wagon.resource.Resource;
 import org.codehaus.plexus.util.FileUtils;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * @author <a href="michal.maczka@dimatics.com">Michal Maczka</a>
@@ -37,8 +44,8 @@ public abstract class AbstractEmbeddedScpWagonWithKeyTest extends StreamingWagon
 
     SshServerEmbedded sshServerEmbedded;
 
-    @Override
-    protected void setUp() throws Exception {
+    @BeforeEach
+    public void setUp() throws Exception {
         super.setUp();
 
         String sshKeyResource = "ssh-keys/id_rsa.pub";
@@ -82,6 +89,7 @@ public abstract class AbstractEmbeddedScpWagonWithKeyTest extends StreamingWagon
         return new File(repository.getBasedir(), resource.getName()).lastModified() / 1000L * 1000L;
     }
 
+    @Test
     public void testConnect() throws Exception {
         getWagon().connect(new Repository("foo", getTestRepositoryUrl()), getAuthInfo());
         assertTrue(true);
@@ -92,6 +100,7 @@ public abstract class AbstractEmbeddedScpWagonWithKeyTest extends StreamingWagon
         return false;
     }
 
+    @Test
     public void testWithSpaces() throws Exception {
         String dir = "foo   test";
         File spaceDirectory = new File(TestData.getRepoPath(), dir);

--- a/wagon-providers/wagon-ssh-common-test/src/main/java/org/apache/maven/wagon/providers/ssh/knownhost/KnownHostsProviderTestCase.java
+++ b/wagon-providers/wagon-ssh-common-test/src/main/java/org/apache/maven/wagon/providers/ssh/knownhost/KnownHostsProviderTestCase.java
@@ -18,20 +18,33 @@
  */
 package org.apache.maven.wagon.providers.ssh.knownhost;
 
-import org.apache.maven.wagon.Wagon;
+import javax.inject.Inject;
+
 import org.apache.maven.wagon.providers.ssh.SshWagon;
 import org.apache.maven.wagon.providers.ssh.TestData;
 import org.apache.maven.wagon.repository.Repository;
 import org.codehaus.plexus.ContainerConfiguration;
 import org.codehaus.plexus.PlexusConstants;
-import org.codehaus.plexus.PlexusTestCase;
+import org.codehaus.plexus.PlexusContainer;
+import org.codehaus.plexus.testing.PlexusTest;
+import org.codehaus.plexus.testing.PlexusTestConfiguration;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  *
  */
-public class KnownHostsProviderTestCase extends PlexusTestCase {
+@PlexusTest
+public class KnownHostsProviderTestCase implements PlexusTestConfiguration {
+
+    @Inject
+    private PlexusContainer container;
+
     @Override
-    protected void customizeContainerConfiguration(ContainerConfiguration configuration) {
+    public void customizeConfiguration(ContainerConfiguration configuration) {
         // the providers are @Named beans now, so the container has to read META-INF/sisu
         configuration.setClassPathScanning(PlexusConstants.SCANNING_INDEX);
     }
@@ -60,6 +73,7 @@ public class KnownHostsProviderTestCase extends PlexusTestCase {
      *
      * @throws Exception on error
      */
+    @Test
     public void testIncorrectKey() throws Exception {
         wagon.setKnownHostsProvider(failHostsProvider);
 
@@ -77,6 +91,7 @@ public class KnownHostsProviderTestCase extends PlexusTestCase {
      *
      * @throws Exception on error
      */
+    @Test
     public void testChangedKey() throws Exception {
         wagon.setKnownHostsProvider(changedHostsProvider);
 
@@ -94,6 +109,7 @@ public class KnownHostsProviderTestCase extends PlexusTestCase {
      *
      * @throws Exception on error
      */
+    @Test
     public void testCorrectKey() throws Exception {
         wagon.setKnownHostsProvider(okHostsProvider);
 
@@ -102,11 +118,11 @@ public class KnownHostsProviderTestCase extends PlexusTestCase {
         assertTrue(true);
     }
 
-    protected void setUp() throws Exception {
-        super.setUp();
+    @BeforeEach
+    public void setUp() throws Exception {
         source = new Repository("test", "scp://" + TestData.getUserName() + "@" + TestData.getHostname() + "/tmp/foo");
 
-        wagon = (SshWagon) lookup(Wagon.ROLE, "scp");
+        wagon = container.lookup(SshWagon.class, "scp");
         wagon.setInteractive(false);
 
         this.okHostsProvider = new SingleKnownHostProvider(TestData.getHostname(), CORRECT_KEY);

--- a/wagon-providers/wagon-ssh-external/src/test/java/org/apache/maven/wagon/providers/ssh/external/EmbeddedScpExternalWagonWithKeyTest.java
+++ b/wagon-providers/wagon-ssh-external/src/test/java/org/apache/maven/wagon/providers/ssh/external/EmbeddedScpExternalWagonWithKeyTest.java
@@ -27,6 +27,7 @@ import org.apache.maven.wagon.authentication.AuthenticationInfo;
 import org.apache.maven.wagon.providers.ssh.AbstractEmbeddedScpWagonWithKeyTest;
 import org.codehaus.plexus.util.cli.CommandLineUtils;
 import org.codehaus.plexus.util.cli.Commandline;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author <a href="michal.maczka@dimatics.com">Michal Maczka</a>
@@ -86,6 +87,7 @@ public class EmbeddedScpExternalWagonWithKeyTest extends AbstractEmbeddedScpWago
         }
     }
 
+    @Test
     public void testFailedGetToStream() throws Exception {
         // ignore this test as it need a stream wagon
     }

--- a/wagon-providers/wagon-ssh-external/src/test/java/org/apache/maven/wagon/providers/ssh/external/ScpExternalWagonTest.java
+++ b/wagon-providers/wagon-ssh-external/src/test/java/org/apache/maven/wagon/providers/ssh/external/ScpExternalWagonTest.java
@@ -26,6 +26,10 @@ import org.apache.maven.wagon.authentication.AuthenticationInfo;
 import org.apache.maven.wagon.providers.ssh.TestData;
 import org.apache.maven.wagon.repository.Repository;
 import org.apache.maven.wagon.resource.Resource;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * @author <a href="michal.maczka@dimatics.com">Michal Maczka</a>
@@ -70,6 +74,7 @@ public class ScpExternalWagonTest extends WagonTestCase {
         return authInfo;
     }
 
+    @Test
     public void testIsPuTTY() throws Exception {
         ScpExternalWagon wagon = (ScpExternalWagon) getWagon();
 

--- a/wagon-providers/wagon-ssh/pom.xml
+++ b/wagon-providers/wagon-ssh/pom.xml
@@ -100,18 +100,6 @@ under the License.
     <dependency>
       <groupId>org.codehaus.plexus</groupId>
       <artifactId>plexus-testing</artifactId>
-      <version>2.1.0</version>
-      <scope>test</scope>
-    </dependency>
-    <!-- ScpWagonTest and its siblings inherit JUnit 4 tests from the published WagonTestCase -->
-    <dependency>
-      <groupId>org.junit.vintage</groupId>
-      <artifactId>junit-vintage-engine</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/wagon-providers/wagon-ssh/src/test/java/org/apache/maven/wagon/providers/ssh/jsch/ScpWagonWithSshPrivateKeySearchTest.java
+++ b/wagon-providers/wagon-ssh/src/test/java/org/apache/maven/wagon/providers/ssh/jsch/ScpWagonWithSshPrivateKeySearchTest.java
@@ -26,6 +26,10 @@ import org.apache.maven.wagon.authentication.AuthenticationInfo;
 import org.apache.maven.wagon.providers.ssh.TestData;
 import org.apache.maven.wagon.repository.Repository;
 import org.apache.maven.wagon.resource.Resource;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * @author <a href="michal.maczka@dimatics.com">Michal Maczka</a>
@@ -54,6 +58,7 @@ public class ScpWagonWithSshPrivateKeySearchTest extends StreamingWagonTestCase 
         return new File(repository.getBasedir(), resource.getName()).lastModified();
     }
 
+    @Test
     public void testMissingPrivateKey() throws Exception {
         File file = File.createTempFile("wagon", "tmp");
         file.delete();
@@ -69,6 +74,7 @@ public class ScpWagonWithSshPrivateKeySearchTest extends StreamingWagonTestCase 
         }
     }
 
+    @Test
     public void testBadPrivateKey() throws Exception {
         File file = File.createTempFile("wagon", "tmp");
         file.deleteOnExit();

--- a/wagon-providers/wagon-webdav-jackrabbit/pom.xml
+++ b/wagon-providers/wagon-webdav-jackrabbit/pom.xml
@@ -78,22 +78,9 @@ under the License.
       <groupId>org.apache.httpcomponents</groupId>
       <artifactId>httpcore</artifactId>
     </dependency>
-
-    <!-- Test dependencies -->
-    <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <scope>test</scope>
-    </dependency>
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <!-- WebDavWagonTest and its subclasses inherit JUnit 4 tests from the published HttpWagonTestCase -->
-    <dependency>
-      <groupId>org.junit.vintage</groupId>
-      <artifactId>junit-vintage-engine</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/wagon-providers/wagon-webdav-jackrabbit/src/test/java/org/apache/maven/wagon/providers/webdav/WebDavWagonTest.java
+++ b/wagon-providers/wagon-webdav-jackrabbit/src/test/java/org/apache/maven/wagon/providers/webdav/WebDavWagonTest.java
@@ -42,6 +42,13 @@ import org.apache.maven.wagon.shared.http.HttpMethodConfiguration;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.servlet.ServletContextHandler;
 import org.eclipse.jetty.servlet.ServletHolder;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /*
  * WebDAV Wagon Test
@@ -81,12 +88,13 @@ public class WebDavWagonTest extends HttpWagonTestCase {
     private void assertURL(String userUrl, String expectedUrl) {
         Repository repo = new Repository("test-geturl", userUrl);
         String actualUrl = (new WebDavWagon()).getURL(repo);
-        assertEquals("WebDavWagon.getURL(" + userUrl + ")", expectedUrl, actualUrl);
+        assertEquals(expectedUrl, actualUrl, "WebDavWagon.getURL(" + userUrl + ")");
     }
 
     /**
      * Tests the maven 2.0.x way to define a webdav URL without SSL.
      */
+    @Test
     public void testGetURLDavHttp() {
         assertURL("dav:http://localhost:9080/dav/", "http://localhost:9080/dav/");
     }
@@ -94,6 +102,7 @@ public class WebDavWagonTest extends HttpWagonTestCase {
     /**
      * Tests the maven 2.0.x way to define a webdav URL with SSL.
      */
+    @Test
     public void testGetURLDavHttps() {
         assertURL("dav:https://localhost:9443/dav/", "https://localhost:9443/dav/");
     }
@@ -101,6 +110,7 @@ public class WebDavWagonTest extends HttpWagonTestCase {
     /**
      * Tests the URI spec way of defining a webdav URL without SSL.
      */
+    @Test
     public void testGetURLDavUri() {
         assertURL("dav://localhost:9080/dav/", "http://localhost:9080/dav/");
     }
@@ -108,6 +118,7 @@ public class WebDavWagonTest extends HttpWagonTestCase {
     /**
      * Tests the URI spec way of defining a webdav URL with SSL.
      */
+    @Test
     public void testGetURLDavUriWithSsl() {
         assertURL("davs://localhost:9443/dav/", "https://localhost:9443/dav/");
     }
@@ -115,6 +126,7 @@ public class WebDavWagonTest extends HttpWagonTestCase {
     /**
      * Tests the URI spec way of defining a webdav URL without SSL.
      */
+    @Test
     public void testGetURLDavPlusHttp() {
         assertURL(
                 "dav+https://localhost:" + getTestRepositoryPort() + "/dav/",
@@ -124,10 +136,12 @@ public class WebDavWagonTest extends HttpWagonTestCase {
     /**
      * Tests the URI spec way of defining a webdav URL with SSL.
      */
+    @Test
     public void testGetURLDavPlusHttps() {
         assertURL("dav+https://localhost:9443/dav/", "https://localhost:9443/dav/");
     }
 
+    @Test
     public void testMkdirs() throws Exception {
         setupWagonTestingFixtures();
 
@@ -172,6 +186,7 @@ public class WebDavWagonTest extends HttpWagonTestCase {
         }
     }
 
+    @Test
     public void testMkdirsWithNoBasedir() throws Exception {
         // WAGON-244
         setupWagonTestingFixtures();
@@ -218,6 +233,7 @@ public class WebDavWagonTest extends HttpWagonTestCase {
      *
      * @throws Exception
      */
+    @Test
     public void testWagonWebDavGetFileList() throws Exception {
         setupWagonTestingFixtures();
 
@@ -244,26 +260,26 @@ public class WebDavWagonTest extends HttpWagonTestCase {
 
         List<String> list = wagon.getFileList(dirName);
 
-        assertNotNull("file list should not be null.", list);
-        assertEquals("file list should contain 6 items", 6, list.size());
+        assertNotNull(list, "file list should not be null.");
+        assertEquals(6, list.size(), "file list should contain 6 items");
 
         for (int i = 0; i < filenames.length; i++) {
-            assertTrue("Filename '" + filenames[i] + "' should be in list.", list.contains(filenames[i]));
+            assertTrue(list.contains(filenames[i]), "Filename '" + filenames[i] + "' should be in list.");
         }
 
         for (int i = 0; i < dirnames.length; i++) {
-            assertTrue("Directory '" + dirnames[i] + "' should be in list.", list.contains(dirnames[i] + "/"));
+            assertTrue(list.contains(dirnames[i] + "/"), "Directory '" + dirnames[i] + "' should be in list.");
         }
 
         ///////////////////////////////////////////////////////////////////////////
         list = wagon.getFileList("");
-        assertNotNull("file list should not be null.", list);
-        assertEquals("file list should contain 1 items", 1, list.size());
+        assertNotNull(list, "file list should not be null.");
+        assertEquals(1, list.size(), "file list should contain 1 items");
 
         ///////////////////////////////////////////////////////////////////////////
         list = wagon.getFileList(dirName + "/test-dir1");
-        assertNotNull("file list should not be null.", list);
-        assertEquals("file list should contain 0 items", 0, list.size());
+        assertNotNull(list, "file list should not be null.");
+        assertEquals(0, list.size(), "file list should contain 0 items");
 
         /////////////////////////////////////////////////////////////////////////////
         try {
@@ -278,6 +294,7 @@ public class WebDavWagonTest extends HttpWagonTestCase {
         tearDownWagonTestingFixtures();
     }
 
+    @Test
     public void testWagonFailsOnPutFailureByDefault() throws Exception {
         setupWagonTestingFixtures();
 
@@ -325,6 +342,7 @@ public class WebDavWagonTest extends HttpWagonTestCase {
         }
     }
 
+    @Test
     public void testWagonContinuesOnPutFailureIfPropertySet() throws Exception {
         setupWagonTestingFixtures();
 
@@ -366,40 +384,40 @@ public class WebDavWagonTest extends HttpWagonTestCase {
         return true;
     }
 
-    protected void testPreemptiveAuthenticationGet(TestSecurityHandler sh, boolean preemptive) {
+    public void testPreemptiveAuthenticationGet(TestSecurityHandler sh, boolean preemptive) {
         if (preemptive) {
             assertEquals(
-                    "testPreemptiveAuthenticationGet preemptive=true: expected 1 request, got "
-                            + sh.handlerRequestResponses,
                     1,
-                    sh.handlerRequestResponses.size());
+                    sh.handlerRequestResponses.size(),
+                    "testPreemptiveAuthenticationGet preemptive=true: expected 1 request, got "
+                            + sh.handlerRequestResponses);
             assertEquals(HttpServletResponse.SC_OK, sh.handlerRequestResponses.get(0).responseCode);
         } else {
             assertEquals(
-                    "testPreemptiveAuthenticationGet preemptive=false: expected 2 requests (401,200), got "
-                            + sh.handlerRequestResponses,
                     2,
-                    sh.handlerRequestResponses.size());
+                    sh.handlerRequestResponses.size(),
+                    "testPreemptiveAuthenticationGet preemptive=false: expected 2 requests (401,200), got "
+                            + sh.handlerRequestResponses);
             assertEquals(HttpServletResponse.SC_UNAUTHORIZED, sh.handlerRequestResponses.get(0).responseCode);
             assertEquals(HttpServletResponse.SC_OK, sh.handlerRequestResponses.get(1).responseCode);
         }
     }
 
-    protected void testPreemptiveAuthenticationPut(TestSecurityHandler sh, boolean preemptive) {
+    public void testPreemptiveAuthenticationPut(TestSecurityHandler sh, boolean preemptive) {
         if (preemptive) {
             assertEquals(
-                    "testPreemptiveAuthenticationPut preemptive=true: expected 2 requests (200,201), got "
-                            + sh.handlerRequestResponses,
                     2,
-                    sh.handlerRequestResponses.size());
+                    sh.handlerRequestResponses.size(),
+                    "testPreemptiveAuthenticationPut preemptive=true: expected 2 requests (200,201), got "
+                            + sh.handlerRequestResponses);
             assertEquals(HttpServletResponse.SC_OK, sh.handlerRequestResponses.get(0).responseCode);
             assertEquals(HttpServletResponse.SC_CREATED, sh.handlerRequestResponses.get(1).responseCode);
         } else {
             assertEquals(
-                    "testPreemptiveAuthenticationPut preemptive=false: expected 3 requests (401,200,201), got "
-                            + sh.handlerRequestResponses,
                     3,
-                    sh.handlerRequestResponses.size());
+                    sh.handlerRequestResponses.size(),
+                    "testPreemptiveAuthenticationPut preemptive=false: expected 3 requests (401,200,201), got "
+                            + sh.handlerRequestResponses);
             assertEquals(HttpServletResponse.SC_UNAUTHORIZED, sh.handlerRequestResponses.get(0).responseCode);
             assertEquals(HttpServletResponse.SC_OK, sh.handlerRequestResponses.get(1).responseCode);
             assertEquals(HttpServletResponse.SC_CREATED, sh.handlerRequestResponses.get(2).responseCode);
@@ -409,20 +427,20 @@ public class WebDavWagonTest extends HttpWagonTestCase {
     /* This method cannot be reasonable used to represend GET and PUT for WebDAV, it would contain too much
      * duplicate code. Leave as-is, but don't use it.
      */
-    protected void testPreemptiveAuthentication(TestSecurityHandler sh, boolean preemptive) {
+    public void testPreemptiveAuthentication(TestSecurityHandler sh, boolean preemptive) {
         if (preemptive) {
             assertEquals(
-                    "testPreemptiveAuthentication preemptive=false: expected 2 requests (200,.), got "
-                            + sh.handlerRequestResponses,
                     2,
-                    sh.handlerRequestResponses.size());
+                    sh.handlerRequestResponses.size(),
+                    "testPreemptiveAuthentication preemptive=false: expected 2 requests (200,.), got "
+                            + sh.handlerRequestResponses);
             assertEquals(HttpServletResponse.SC_OK, sh.handlerRequestResponses.get(0).responseCode);
         } else {
             assertEquals(
-                    "testPreemptiveAuthentication preemptive=false: expected 3 requests (401,200,200), got "
-                            + sh.handlerRequestResponses,
                     3,
-                    sh.handlerRequestResponses.size());
+                    sh.handlerRequestResponses.size(),
+                    "testPreemptiveAuthentication preemptive=false: expected 3 requests (401,200,200), got "
+                            + sh.handlerRequestResponses);
             assertEquals(HttpServletResponse.SC_UNAUTHORIZED, sh.handlerRequestResponses.get(0).responseCode);
             assertEquals(HttpServletResponse.SC_OK, sh.handlerRequestResponses.get(1).responseCode);
             assertEquals(HttpServletResponse.SC_OK, sh.handlerRequestResponses.get(2).responseCode);
@@ -432,38 +450,38 @@ public class WebDavWagonTest extends HttpWagonTestCase {
     @Override
     protected void checkRequestResponseForRedirectPutWithFullUrl(
             RedirectHandler redirectHandler, PutHandler putHandler) {
-        assertEquals("found:" + putHandler.handlerRequestResponses, 1, putHandler.handlerRequestResponses.size());
+        assertEquals(1, putHandler.handlerRequestResponses.size(), "found:" + putHandler.handlerRequestResponses);
         assertEquals(
-                "found:" + putHandler.handlerRequestResponses,
                 HttpServletResponse.SC_CREATED,
-                putHandler.handlerRequestResponses.get(0).responseCode);
+                putHandler.handlerRequestResponses.get(0).responseCode,
+                "found:" + putHandler.handlerRequestResponses);
         assertEquals(
-                "found:" + redirectHandler.handlerRequestResponses, 2, redirectHandler.handlerRequestResponses.size());
+                2, redirectHandler.handlerRequestResponses.size(), "found:" + redirectHandler.handlerRequestResponses);
         assertEquals(
-                "found:" + redirectHandler.handlerRequestResponses,
                 HttpServletResponse.SC_SEE_OTHER,
-                redirectHandler.handlerRequestResponses.get(0).responseCode);
+                redirectHandler.handlerRequestResponses.get(0).responseCode,
+                "found:" + redirectHandler.handlerRequestResponses);
     }
 
     @Override
     protected void checkRequestResponseForRedirectPutWithRelativeUrl(
             RedirectHandler redirectHandler, PutHandler putHandler) {
-        assertEquals("found:" + putHandler.handlerRequestResponses, 0, putHandler.handlerRequestResponses.size());
+        assertEquals(0, putHandler.handlerRequestResponses.size(), "found:" + putHandler.handlerRequestResponses);
 
         assertEquals(
-                "found:" + redirectHandler.handlerRequestResponses, 4, redirectHandler.handlerRequestResponses.size());
+                4, redirectHandler.handlerRequestResponses.size(), "found:" + redirectHandler.handlerRequestResponses);
         assertEquals(
-                "found:" + redirectHandler.handlerRequestResponses,
                 HttpServletResponse.SC_SEE_OTHER,
-                redirectHandler.handlerRequestResponses.get(0).responseCode);
+                redirectHandler.handlerRequestResponses.get(0).responseCode,
+                "found:" + redirectHandler.handlerRequestResponses);
         assertEquals(
-                "found:" + redirectHandler.handlerRequestResponses,
                 HttpServletResponse.SC_OK,
-                redirectHandler.handlerRequestResponses.get(1).responseCode);
+                redirectHandler.handlerRequestResponses.get(1).responseCode,
+                "found:" + redirectHandler.handlerRequestResponses);
         assertEquals(
-                "found:" + redirectHandler.handlerRequestResponses,
                 HttpServletResponse.SC_SEE_OTHER,
-                redirectHandler.handlerRequestResponses.get(2).responseCode);
+                redirectHandler.handlerRequestResponses.get(2).responseCode,
+                "found:" + redirectHandler.handlerRequestResponses);
     }
 
     @Override

--- a/wagon-tcks/wagon-tck-http/pom.xml
+++ b/wagon-tcks/wagon-tck-http/pom.xml
@@ -38,6 +38,10 @@ under the License.
       <scope>compile</scope>
     </dependency>
     <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
+    </dependency>
+    <dependency>
       <groupId>com.google.inject</groupId>
       <artifactId>guice</artifactId>
       <classifier>classes</classifier>
@@ -59,11 +63,6 @@ under the License.
     <dependency>
       <groupId>org.apache.maven.wagon</groupId>
       <artifactId>wagon-provider-api</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>org.codehaus.plexus</groupId>

--- a/wagon-tcks/wagon-tck-http/src/main/java/org/apache/maven/wagon/tck/http/Assertions.java
+++ b/wagon-tcks/wagon-tck-http/src/main/java/org/apache/maven/wagon/tck/http/Assertions.java
@@ -34,9 +34,9 @@ import org.codehaus.plexus.util.IOUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public final class Assertions {
 
@@ -50,7 +50,7 @@ public final class Assertions {
         String content = readResource(resourceBase, resourceName);
         String test = new String(Files.readAllBytes(output.toPath()));
 
-        assertEquals(whyWouldItFail, content, test);
+        assertEquals(content, test, whyWouldItFail);
     }
 
     private static String readResource(final String base, final String name) throws IOException {
@@ -89,95 +89,95 @@ public final class Assertions {
         // TODO: handle AuthenticationException for Wagon.connect() calls
         assertNotNull(e);
         try {
-            assertTrue("only verify instances of WagonException", e instanceof WagonException);
+            assertTrue(e instanceof WagonException, "only verify instances of WagonException");
 
             String reasonPhrase;
             String assertMessageForBadMessage = "exception message not described properly";
 
             if (proxyInfo != null) {
                 assertTrue(
-                        "message should end with proxy information if proxy was used",
-                        e.getMessage().endsWith(proxyInfo.toString()));
+                        e.getMessage().endsWith(proxyInfo.toString()),
+                        "message should end with proxy information if proxy was used");
             }
 
             switch (forStatusCode) {
                 case HttpServletResponse.SC_NOT_FOUND:
                     // TODO: add test for 410: Gone?
                     assertTrue(
-                            "404 not found response should throw ResourceDoesNotExistException",
-                            e instanceof ResourceDoesNotExistException);
+                            e instanceof ResourceDoesNotExistException,
+                            "404 not found response should throw ResourceDoesNotExistException");
                     reasonPhrase = (forReasonPhrase == null || forReasonPhrase.isEmpty())
                             ? " Not Found"
                             : (" " + forReasonPhrase);
                     assertEquals(
-                            assertMessageForBadMessage,
                             "resource missing at " + forUrl + ", status: 404" + reasonPhrase,
-                            e.getMessage());
+                            e.getMessage(),
+                            assertMessageForBadMessage);
                     break;
 
                 case HttpServletResponse.SC_UNAUTHORIZED:
                     // FIXME assumes Wagon.get()/put() returning 401 instead of Wagon.connect()
                     assertTrue(
+                            e instanceof AuthorizationException,
                             "401 Unauthorized should throw AuthorizationException since "
                                     + " AuthenticationException is not explicitly declared as thrown from wagon "
-                                    + "methods",
-                            e instanceof AuthorizationException);
+                                    + "methods");
                     reasonPhrase = (forReasonPhrase == null || forReasonPhrase.isEmpty())
                             ? " Unauthorized"
                             : (" " + forReasonPhrase);
                     assertEquals(
-                            assertMessageForBadMessage,
                             "authentication failed for " + forUrl + ", status: 401" + reasonPhrase,
-                            e.getMessage());
+                            e.getMessage(),
+                            assertMessageForBadMessage);
                     break;
 
                 case HttpServletResponse.SC_PROXY_AUTHENTICATION_REQUIRED:
                     assertTrue(
-                            "407 Proxy authentication required should throw AuthorizationException",
-                            e instanceof AuthorizationException);
+                            e instanceof AuthorizationException,
+                            "407 Proxy authentication required should throw AuthorizationException");
                     reasonPhrase = (forReasonPhrase == null || forReasonPhrase.isEmpty())
                             ? " Proxy Authentication Required"
                             : (" " + forReasonPhrase);
                     assertEquals(
-                            assertMessageForBadMessage,
                             "proxy authentication failed for " + forUrl + ", status: 407" + reasonPhrase,
-                            e.getMessage());
+                            e.getMessage(),
+                            assertMessageForBadMessage);
                     break;
 
                 case HttpServletResponse.SC_FORBIDDEN:
                     assertTrue(
-                            "403 Forbidden should throw AuthorizationException", e instanceof AuthorizationException);
+                            e instanceof AuthorizationException, "403 Forbidden should throw AuthorizationException");
                     reasonPhrase = (forReasonPhrase == null || forReasonPhrase.isEmpty())
                             ? " Forbidden"
                             : (" " + forReasonPhrase);
                     assertEquals(
-                            assertMessageForBadMessage,
                             "authorization failed for " + forUrl + ", status: 403" + reasonPhrase,
-                            e.getMessage());
+                            e.getMessage(),
+                            assertMessageForBadMessage);
                     break;
 
                 default:
                     assertTrue(
-                            "transfer failures should at least be wrapped in a TransferFailedException",
-                            e instanceof TransferFailedException);
+                            e instanceof TransferFailedException,
+                            "transfer failures should at least be wrapped in a TransferFailedException");
 
                     // the status code and reason phrase cannot always be learned due to implementation limitations
                     // so the message may not include them, but the implementation should use a consistent format
                     assertTrue(
-                            "message should always include url tried: " + e.getMessage(),
-                            e.getMessage().startsWith("transfer failed for " + forUrl));
+                            e.getMessage().startsWith("transfer failed for " + forUrl),
+                            "message should always include url tried: " + e.getMessage());
 
                     String statusCodeStr = forStatusCode == NO_RESPONSE_STATUS_CODE ? "" : ", status: " + forStatusCode;
                     if (forStatusCode != NO_RESPONSE_STATUS_CODE) {
 
                         assertTrue(
-                                "if there was a response status line, the status code should be >= 400",
-                                forStatusCode >= HttpServletResponse.SC_BAD_REQUEST);
+                                forStatusCode >= HttpServletResponse.SC_BAD_REQUEST,
+                                "if there was a response status line, the status code should be >= 400");
 
                         if (e.getMessage().length() > ("transfer failed for " + forUrl).length()) {
                             assertTrue(
-                                    "message should include url and status code: " + e.getMessage(),
-                                    e.getMessage().startsWith("transfer failed for " + forUrl + statusCodeStr));
+                                    e.getMessage().startsWith("transfer failed for " + forUrl + statusCodeStr),
+                                    "message should include url and status code: " + e.getMessage());
                         }
 
                         reasonPhrase = forReasonPhrase == null ? "" : " " + forReasonPhrase;
@@ -186,10 +186,9 @@ public final class Assertions {
                                 && e.getMessage().length()
                                         > ("transfer failed for " + forUrl + statusCodeStr).length()) {
                             assertTrue(
-                                    "message should include url and status code and reason phrase: " + e.getMessage(),
                                     e.getMessage()
-                                            .startsWith(
-                                                    "transfer failed for " + forUrl + statusCodeStr + reasonPhrase));
+                                            .startsWith("transfer failed for " + forUrl + statusCodeStr + reasonPhrase),
+                                    "message should include url and status code and reason phrase: " + e.getMessage());
                         }
                     }
 

--- a/wagon-tcks/wagon-tck-http/src/main/java/org/apache/maven/wagon/tck/http/GetWagonTests.java
+++ b/wagon-tcks/wagon-tck-http/src/main/java/org/apache/maven/wagon/tck/http/GetWagonTests.java
@@ -40,15 +40,15 @@ import org.apache.maven.wagon.tck.http.fixture.ServerFixture;
 import org.apache.maven.wagon.tck.http.fixture.ServletExceptionServlet;
 import org.apache.maven.wagon.tck.http.util.ValueHolder;
 import org.codehaus.plexus.component.configurator.ComponentConfigurationException;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
-import static junit.framework.Assert.assertTrue;
-import static junit.framework.Assert.fail;
 import static org.apache.maven.wagon.tck.http.Assertions.NO_RESPONSE_STATUS_CODE;
 import static org.apache.maven.wagon.tck.http.Assertions.assertFileContentsFromResource;
 import static org.apache.maven.wagon.tck.http.Assertions.assertWagonExceptionMessage;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  *
@@ -65,7 +65,7 @@ public class GetWagonTests extends HttpWagonTests {
     }
 
     @Test
-    @Ignore("FIX ME!")
+    @Disabled("FIX ME!")
     public void proxied()
             throws ConnectionException, AuthenticationException, ComponentConfigurationException, IOException,
                     TransferFailedException, ResourceDoesNotExistException, AuthorizationException {
@@ -156,7 +156,7 @@ public class GetWagonTests extends HttpWagonTests {
         logger.info("Interrupting thread.");
         t.interrupt();
 
-        assertNotNull("TransferFailedException should have been thrown.", holder.getValue());
+        assertNotNull(holder.getValue(), "TransferFailedException should have been thrown.");
         assertWagonExceptionMessage(holder.getValue(), NO_RESPONSE_STATUS_CODE, getBaseUrl() + "infinite/", "", null);
     }
 
@@ -425,7 +425,7 @@ public class GetWagonTests extends HttpWagonTests {
             authFailure = true;
         }
 
-        assertTrue("Authentication/Authorization should have failed.", authFailure);
+        assertTrue(authFailure, "Authentication/Authorization should have failed.");
     }
 
     protected void testSuccessfulGet(final String path)

--- a/wagon-tcks/wagon-tck-http/src/main/java/org/apache/maven/wagon/tck/http/HttpWagonTests.java
+++ b/wagon-tcks/wagon-tck-http/src/main/java/org/apache/maven/wagon/tck/http/HttpWagonTests.java
@@ -37,10 +37,10 @@ import org.codehaus.plexus.PlexusConstants;
 import org.codehaus.plexus.PlexusContainer;
 import org.codehaus.plexus.component.configurator.ComponentConfigurationException;
 import org.codehaus.plexus.component.repository.exception.ComponentLifecycleException;
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.BeforeClass;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -66,14 +66,14 @@ public abstract class HttpWagonTests {
     protected static final Logger logger = LoggerFactory.getLogger(HttpWagonTests.class);
     // CHECKSTYLE_ON: ConstantName
 
-    @Before
+    @BeforeEach
     public void beforeEach() throws Exception {
         serverFixture = new ServerFixture(isSsl());
         serverFixture.start();
         wagon = (Wagon) container.lookup(Wagon.ROLE, configurator.getWagonHint());
     }
 
-    @BeforeClass
+    @BeforeAll
     public static void beforeAll() throws Exception {
         File keystore = getResource(ServerFixture.SERVER_SSL_KEYSTORE_RESOURCE_PATH);
 
@@ -91,7 +91,7 @@ public abstract class HttpWagonTests {
         configurator = (WagonTestCaseConfigurator) container.lookup(WagonTestCaseConfigurator.class.getName());
     }
 
-    @After
+    @AfterEach
     public void afterEach() {
         try {
             wagon.disconnect();
@@ -120,7 +120,7 @@ public abstract class HttpWagonTests {
         }
     }
 
-    @AfterClass
+    @AfterAll
     public static void afterAll() {
         if (container != null) {
             try {


### PR DESCRIPTION
Completes the JUnit 5 move for the test base classes that wagon publishes: `WagonTestCase`,
`CommandExecutorTestCase`, `HttpWagonTestCase` and `KnownHostsProviderTestCase`. These are
`src/main/java` in released artifacts, so the change reaches consumers who extend them —
which drove three decisions worth a reviewer's attention.

**`plexus-testing` is a compile-scope dependency of `wagon-provider-test` and
`wagon-ssh-common-test`.** `@PlexusTest` sits on published classes, so a consumer extending
`WagonTestCase` needs it on their own compile path; test scope would not propagate. Its version
moves to the root `dependencyManagement` alongside the other third-party versions, since
`wagon-ssh` already declared it and this change would otherwise make three copies.

**Six members disappeared with `PlexusTestCase` and are replaced rather than dropped**, so
subclasses outside this repo keep compiling: `getTestFile`, `getTestPath` and `getBasedir`
delegate to `PlexusExtension`; `getName()` is served by a `TestInfo` callback kept separate from
`setUp()` — eight subclasses override `setUp()` and call `super.setUp()`, and widening that
signature would break every one of them.

**`runTest()` and the `testSkipped` flag are gone, replaced by `assumeTrue`.** This changes a CI
signal: on a machine without `cvs`, the old mechanism reported those wagon-scm tests as
*passing*, and they are now reported as *skipped* (0 → 14 locally). Same tests, honest status.

**Checkstyle `FileLength` is suppressed for `HttpWagonTestCase`** via a new
`src/config/checkstyle-suppressions.xml`. One `@Test` per method took it one line past the
inherited 2000-line limit. Neither `@SuppressWarnings` nor a `CHECKSTYLE_OFF` comment can
suppress it — the reasons are in a comment in that file. Splitting the class is a separate change.

Verified: per-module `<testcase>` element counts in the surefire XML are unchanged against
`f289bdd5` across all eight provider modules (22/23/295/214/42/0/0/295), with no errors or
failures.

*This change was created with AI assistance.*
