### PR TITLE
Align the shared test base classes with master

### DIFF
--- a/wagon-provider-test/src/main/java/org/apache/maven/wagon/StreamingWagonTestCase.java
+++ b/wagon-provider-test/src/main/java/org/apache/maven/wagon/StreamingWagonTestCase.java
@@ -23,14 +23,15 @@ import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.text.SimpleDateFormat;
 
 import org.apache.maven.wagon.observers.ChecksumObserver;
 import org.apache.maven.wagon.resource.Resource;
-import org.codehaus.plexus.util.FileUtils;
-import org.codehaus.plexus.util.IOUtil;
 import org.junit.jupiter.api.Test;
 
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -71,14 +72,9 @@ public abstract class StreamingWagonTestCase extends WagonTestCase {
 
         destFile.deleteOnExit();
 
-        OutputStream stream = null;
-
-        try {
-            stream = new FileOutputStream(destFile);
+        try (OutputStream stream = new FileOutputStream(destFile)) {
             wagon.getToStream("fubar.txt", stream);
             fail("File was found when it shouldn't have been");
-            stream.close();
-            stream = null;
         } catch (ResourceDoesNotExistException e) {
             // expected
             assertTrue(true);
@@ -86,8 +82,6 @@ public abstract class StreamingWagonTestCase extends WagonTestCase {
             wagon.removeTransferListener(checksumObserver);
 
             wagon.disconnect();
-
-            IOUtil.close(stream);
 
             tearDownWagonTestingFixtures();
         }
@@ -163,13 +157,10 @@ public abstract class StreamingWagonTestCase extends WagonTestCase {
             wagon.connect(testRepository, getAuthInfo());
             destFile = FileTestUtils.createUniqueFile(getName(), getName());
             destFile.deleteOnExit();
-            OutputStream stream = null;
-            try {
-                stream = new FileOutputStream(destFile);
+
+            try (OutputStream stream = new FileOutputStream(destFile)) {
                 wagon.getIfNewerToStream("fubar.txt", stream, 0);
                 fail("File was found when it shouldn't have been");
-                stream.close();
-                stream = null;
             } catch (ResourceDoesNotExistException e) {
                 // expected
                 assertTrue(true);
@@ -177,8 +168,6 @@ public abstract class StreamingWagonTestCase extends WagonTestCase {
                 wagon.removeTransferListener(checksumObserver);
 
                 wagon.disconnect();
-
-                IOUtil.close(stream);
 
                 tearDownWagonTestingFixtures();
             }
@@ -202,22 +191,22 @@ public abstract class StreamingWagonTestCase extends WagonTestCase {
 
         assertEquals("6b144b7285ffd6b0bc8300da162120b9", checksumObserver.getActualChecksum(), "compare checksums");
 
-        // Now compare the conents of the artifact that was placed in
+        // Now compare the contents of the artifact that was placed in
         // the repository with the contents of the artifact that was
         // retrieved from the repository.
 
-        String sourceContent = FileUtils.fileRead(sourceFile);
+        byte[] sourceContent = Files.readAllBytes(sourceFile.toPath());
 
-        String destContent = FileUtils.fileRead(destFile);
+        byte[] destContent = Files.readAllBytes(destFile.toPath());
 
-        assertEquals(sourceContent, destContent);
+        assertArrayEquals(sourceContent, destContent);
     }
 
     private int putStream() throws Exception {
         String content = "test-resource.txt\n";
         sourceFile = new File(FileTestUtils.getTestOutputDir(), "test-resource");
         sourceFile.getParentFile().mkdirs();
-        FileUtils.fileWrite(sourceFile.getAbsolutePath(), content);
+        Files.write(sourceFile.toPath().toAbsolutePath(), content.getBytes(StandardCharsets.UTF_8));
 
         StreamingWagon wagon = (StreamingWagon) getWagon();
 
@@ -227,17 +216,10 @@ public abstract class StreamingWagonTestCase extends WagonTestCase {
 
         connectWagon(wagon);
 
-        InputStream stream = null;
-
-        try {
-            stream = new FileInputStream(sourceFile);
+        try (InputStream stream = new FileInputStream(sourceFile)) {
             wagon.putFromStream(stream, resource, sourceFile.length(), sourceFile.lastModified());
-            stream.close();
-            stream = null;
         } catch (Exception e) {
             logger.error("error while putting resources to the FTP Server", e);
-        } finally {
-            IOUtil.close(stream);
         }
 
         disconnectWagon(wagon);
@@ -258,17 +240,10 @@ public abstract class StreamingWagonTestCase extends WagonTestCase {
 
         connectWagon(wagon);
 
-        OutputStream stream = null;
-
-        try {
-            stream = new FileOutputStream(destFile);
+        try (OutputStream stream = new FileOutputStream(destFile)) {
             wagon.getToStream(this.resource, stream);
-            stream.close();
-            stream = null;
         } catch (Exception e) {
             logger.error("error while reading resources from the FTP Server", e);
-        } finally {
-            IOUtil.close(stream);
         }
 
         disconnectWagon(wagon);

--- a/wagon-provider-test/src/main/java/org/apache/maven/wagon/WagonTestCase.java
+++ b/wagon-provider-test/src/main/java/org/apache/maven/wagon/WagonTestCase.java
@@ -24,6 +24,7 @@ import java.io.File;
 import java.io.IOException;
 import java.lang.reflect.Method;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.security.NoSuchAlgorithmException;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
@@ -56,6 +57,7 @@ import org.mockito.stubbing.Answer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -371,9 +373,9 @@ public abstract class WagonTestCase implements PlexusTestConfiguration {
             // the repository with the contents of the artifact that was
             // retrieved from the repository.
 
-            String sourceContent = FileUtils.fileRead(sourceFile);
-            String destContent = FileUtils.fileRead(destFile);
-            assertEquals(sourceContent, destContent);
+            byte[] sourceContent = Files.readAllBytes(sourceFile.toPath());
+            byte[] destContent = Files.readAllBytes(destFile.toPath());
+            assertArrayEquals(sourceContent, destContent);
         } else {
             assertNull(checksumObserver.getActualChecksum(), "check checksum is null");
 
@@ -624,7 +626,7 @@ public abstract class WagonTestCase implements PlexusTestConfiguration {
     private void writeTestFile(String child) throws IOException {
         File dir = new File(sourceFile, child);
         dir.getParentFile().mkdirs();
-        FileUtils.fileWrite(dir.getAbsolutePath(), child);
+        Files.write(dir.toPath().toAbsolutePath(), child.getBytes());
     }
 
     @Test
@@ -835,7 +837,7 @@ public abstract class WagonTestCase implements PlexusTestConfiguration {
     protected void putFile(String resourceName, String testFileName, String content) throws Exception {
         sourceFile = new File(FileTestUtils.getTestOutputDir(), testFileName);
         sourceFile.getParentFile().mkdirs();
-        FileUtils.fileWrite(sourceFile.getAbsolutePath(), content);
+        Files.write(sourceFile.toPath().toAbsolutePath(), content.getBytes());
 
         Wagon wagon = getWagon();
 
@@ -990,15 +992,13 @@ public abstract class WagonTestCase implements PlexusTestConfiguration {
 
         assertEquals(TEST_CKSUM, checksumObserver.getActualChecksum(), "compare checksums");
 
-        // Now compare the conents of the artifact that was placed in
+        // Now compare the contents of the artifact that was placed in
         // the repository with the contents of the artifact that was
         // retrieved from the repository.
 
-        String sourceContent = FileUtils.fileRead(sourceFile);
-
-        String destContent = FileUtils.fileRead(destFile);
-
-        assertEquals(sourceContent, destContent);
+        byte[] sourceContent = Files.readAllBytes(sourceFile.toPath());
+        byte[] destContent = Files.readAllBytes(destFile.toPath());
+        assertArrayEquals(sourceContent, destContent);
     }
 
     // ----------------------------------------------------------------------

--- a/wagon-provider-test/src/main/java/org/apache/maven/wagon/http/HttpWagonTestCase.java
+++ b/wagon-provider-test/src/main/java/org/apache/maven/wagon/http/HttpWagonTestCase.java
@@ -31,6 +31,8 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.lang.reflect.Method;
 import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Enumeration;
@@ -80,6 +82,7 @@ import org.eclipse.jetty.util.security.Constraint;
 import org.eclipse.jetty.util.security.Password;
 import org.junit.jupiter.api.Test;
 
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -114,8 +117,6 @@ public abstract class HttpWagonTestCase extends StreamingWagonTestCase {
         repositoryDirectory.mkdirs();
 
         server = new Server();
-        // connector = new ServerConnector( server, new HttpConnectionFactory( new HttpConfiguration() ) );
-        // server.addConnector( connector );
         connector = addConnector(server);
 
         PutHandler putHandler = new PutHandler(repositoryDirectory);
@@ -452,63 +453,13 @@ public abstract class HttpWagonTestCase extends StreamingWagonTestCase {
 
             wagon.disconnect();
 
-            String destContent = FileUtils.fileRead(destFile);
+            String destContent = new String(Files.readAllBytes(destFile.toPath()));
 
             assertEquals(sourceContent, destContent);
         } finally {
             server.stop();
         }
     }
-
-    /* This test cannot be enabled because we cannot tell GzipFilter to compress with deflate only
-    public void testDeflateGet()
-            throws Exception
-        {
-            Server server = new Server( );
-
-            String localRepositoryPath = FileTestUtils.getTestOutputDir().toString();
-            ServletContextHandler root = new ServletContextHandler( ServletContextHandler.SESSIONS );
-            root.setResourceBase( localRepositoryPath );
-            ServletHolder servletHolder = new ServletHolder( new DefaultServlet() );
-            root.addServlet( servletHolder, "/*" );
-            FilterHolder filterHolder = new FilterHolder( new GzipFilter() );
-            root.addFilter( filterHolder, "/deflate/*", EnumSet.of( DispatcherType.REQUEST ) );
-            addConnector( server );
-            server.setHandler( root );
-            server.start();
-
-            try
-            {
-                Wagon wagon = getWagon();
-
-                Repository testRepository = new Repository( "id", getRepositoryUrl( server ) );
-
-                File sourceFile = new File( localRepositoryPath + "/deflate" );
-
-                sourceFile.deleteOnExit();
-
-                String resName = "deflate-res.txt";
-                String sourceContent = writeTestFile( sourceFile, resName, null );
-
-                wagon.connect( testRepository );
-
-                File destFile = FileTestUtils.createUniqueFile( getName(), getName() );
-
-                destFile.deleteOnExit();
-
-                wagon.get( "deflate/" + resName, destFile );
-
-                wagon.disconnect();
-
-                String destContent = FileUtils.fileRead( destFile );
-
-                assertEquals( sourceContent, destContent );
-            }
-            finally
-            {
-                server.stop();
-            }
-        }*/
 
     @Test
     public void testProxiedRequest() throws Exception {
@@ -608,7 +559,7 @@ public abstract class HttpWagonTestCase extends StreamingWagonTestCase {
             wagon.getToStream("resource", fileOutputStream);
             fileOutputStream.flush();
             fileOutputStream.close();
-            String found = FileUtils.fileRead(tmpResult);
+            String found = new String(Files.readAllBytes(tmpResult.toPath()));
             assertEquals("Hello, World!", found, "found:'" + found + "'");
 
             checkHandlerResult(redirectHandler.handlerRequestResponses, HttpServletResponse.SC_SEE_OTHER);
@@ -664,7 +615,7 @@ public abstract class HttpWagonTestCase extends StreamingWagonTestCase {
 
         try {
             wagon.get("resource", tmpResult);
-            String found = FileUtils.fileRead(tmpResult);
+            String found = new String(Files.readAllBytes(tmpResult.toPath()));
             assertEquals("Hello, World!", found, "found:'" + found + "'");
 
             checkHandlerResult(redirectHandler.handlerRequestResponses, HttpServletResponse.SC_SEE_OTHER);
@@ -731,11 +682,13 @@ public abstract class HttpWagonTestCase extends StreamingWagonTestCase {
             File tempFile = File.createTempFile("wagon", "tmp");
             tempFile.deleteOnExit();
             String content = "put top secret";
-            FileUtils.fileWrite(tempFile.getAbsolutePath(), content);
+            Files.write(tempFile.toPath().toAbsolutePath(), content.getBytes(StandardCharsets.UTF_8));
 
             try (FileInputStream fileInputStream = new FileInputStream(tempFile)) {
                 wagon.putFromStream(fileInputStream, "test-secured-put-resource", content.length(), -1);
-                assertEquals(content, FileUtils.fileRead(sourceFile.getAbsolutePath()));
+                String actual =
+                        new String(Files.readAllBytes(sourceFile.toPath().toAbsolutePath()), StandardCharsets.UTF_8);
+                assertEquals(content, actual);
 
                 checkRequestResponseForRedirectPutWithFullUrl(redirectHandler, putHandler);
             } finally {
@@ -792,11 +745,13 @@ public abstract class HttpWagonTestCase extends StreamingWagonTestCase {
             File tempFile = File.createTempFile("wagon", "tmp");
             tempFile.deleteOnExit();
             String content = "put top secret";
-            FileUtils.fileWrite(tempFile.getAbsolutePath(), content);
+            Files.write(tempFile.toPath().toAbsolutePath(), content.getBytes(StandardCharsets.UTF_8));
 
             try (FileInputStream fileInputStream = new FileInputStream(tempFile)) {
                 wagon.putFromStream(fileInputStream, "test-secured-put-resource", content.length(), -1);
-                assertEquals(content, FileUtils.fileRead(sourceFile.getAbsolutePath()));
+                assertEquals(
+                        content,
+                        new String(Files.readAllBytes(sourceFile.toPath().toAbsolutePath()), StandardCharsets.UTF_8));
 
                 checkRequestResponseForRedirectPutWithRelativeUrl(redirectHandler, putHandler);
             } finally {
@@ -884,12 +839,13 @@ public abstract class HttpWagonTestCase extends StreamingWagonTestCase {
 
             File tempFile = File.createTempFile("wagon", "tmp");
             tempFile.deleteOnExit();
-            String content = "put top secret";
-            FileUtils.fileWrite(tempFile.getAbsolutePath(), content);
+            byte[] content = "put top secret".getBytes(StandardCharsets.UTF_8);
+            Files.write(tempFile.toPath().toAbsolutePath(), content);
 
             try {
                 wagon.put(tempFile, "test-secured-put-resource");
-                assertEquals(content, FileUtils.fileRead(sourceFile.getAbsolutePath()));
+                assertArrayEquals(
+                        content, Files.readAllBytes(sourceFile.toPath().toAbsolutePath()));
 
                 checkRequestResponseForRedirectPutWithFullUrl(redirectHandler, putHandler);
             } finally {
@@ -939,12 +895,13 @@ public abstract class HttpWagonTestCase extends StreamingWagonTestCase {
 
             File tempFile = File.createTempFile("wagon", "tmp");
             tempFile.deleteOnExit();
-            String content = "put top secret";
-            FileUtils.fileWrite(tempFile.getAbsolutePath(), content);
+            byte[] content = "put top secret".getBytes(StandardCharsets.UTF_8);
+            Files.write(tempFile.toPath().toAbsolutePath(), content);
 
             try {
                 wagon.put(tempFile, "test-secured-put-resource");
-                assertEquals(content, FileUtils.fileRead(sourceFile.getAbsolutePath()));
+                assertArrayEquals(
+                        content, Files.readAllBytes(sourceFile.toPath().toAbsolutePath()));
 
                 checkRequestResponseForRedirectPutWithRelativeUrl(redirectHandler, putHandler);
             } finally {
@@ -991,7 +948,7 @@ public abstract class HttpWagonTestCase extends StreamingWagonTestCase {
             File tempFile = File.createTempFile("wagon", "tmp");
             tempFile.deleteOnExit();
             String content = "put top secret";
-            FileUtils.fileWrite(tempFile.getAbsolutePath(), content);
+            Files.write(tempFile.toPath().toAbsolutePath(), content.getBytes(StandardCharsets.UTF_8));
 
             try (FileInputStream fileInputStream = new FileInputStream(tempFile)) {
                 wagon.putFromStream(fileInputStream, "test-secured-put-resource", content.length(), -1);
@@ -1085,7 +1042,7 @@ public abstract class HttpWagonTestCase extends StreamingWagonTestCase {
 
             String localRepositoryPath = FileTestUtils.getTestOutputDir().toString();
             File sourceFile = new File(localRepositoryPath, "test-proxied-resource");
-            FileUtils.fileWrite(sourceFile.getAbsolutePath(), "content");
+            Files.write(sourceFile.toPath().toAbsolutePath(), "content".getBytes(StandardCharsets.UTF_8));
 
             wagon.connect(testRepository, proxyInfo);
 
@@ -1139,7 +1096,7 @@ public abstract class HttpWagonTestCase extends StreamingWagonTestCase {
 
             String localRepositoryPath = FileTestUtils.getTestOutputDir().toString();
             File sourceFile = new File(localRepositoryPath, "test-proxied-resource");
-            FileUtils.fileWrite(sourceFile.getAbsolutePath(), "content");
+            Files.write(sourceFile.toPath().toAbsolutePath(), "content".getBytes(StandardCharsets.UTF_8));
 
             wagon.connect(testRepository, proxyInfoProvider);
 
@@ -1208,7 +1165,7 @@ public abstract class HttpWagonTestCase extends StreamingWagonTestCase {
             Repository testRepository = new Repository("id", getRepositoryUrl(server));
 
             File sourceFile = new File(localRepositoryPath, "test-secured-resource");
-            FileUtils.fileWrite(sourceFile.getAbsolutePath(), "top secret");
+            Files.write(sourceFile.toPath().toAbsolutePath(), "top secret".getBytes(StandardCharsets.UTF_8));
 
             wagon.connect(testRepository, authInfo);
 
@@ -1220,12 +1177,10 @@ public abstract class HttpWagonTestCase extends StreamingWagonTestCase {
                 wagon.disconnect();
             }
 
-            FileInputStream in = new FileInputStream(file);
-
-            assertEquals("top secret", IOUtil.toString(in));
+            assertEquals("top secret", new String(Files.readAllBytes(file.toPath()), StandardCharsets.UTF_8));
 
             /*
-             * We need to wait a bit for all Jetty workers/threads to complete their work. Otherwise
+             * We need to wait a bit for all Jetty workers/threads to complete their work. Otherwise,
              * we may suffer from race conditions where handlerRequestResponses list is not completely
              * populated and its premature iteration in testPreemptiveAuthenticationGet will lead to
              * a test failure.
@@ -1262,7 +1217,7 @@ public abstract class HttpWagonTestCase extends StreamingWagonTestCase {
             Repository testRepository = new Repository("id", getRepositoryUrl(server));
 
             File sourceFile = new File(localRepositoryPath, "test-secured-resource");
-            FileUtils.fileWrite(sourceFile.getAbsolutePath(), "top secret");
+            Files.write(sourceFile.toPath().toAbsolutePath(), "top secret".getBytes(StandardCharsets.US_ASCII));
 
             wagon.connect(testRepository, authInfo);
 
@@ -1276,7 +1231,7 @@ public abstract class HttpWagonTestCase extends StreamingWagonTestCase {
             assertEquals("top secret", out.toString("US-ASCII"));
 
             /*
-             * We need to wait a bit for all Jetty workers/threads to complete their work. Otherwise
+             * We need to wait a bit for all Jetty workers/threads to complete their work. Otherwise,
              * we may suffer from race conditions where handlerRequestResponses list is not completely
              * populated and its premature iteration in testPreemptiveAuthenticationGet will lead to
              * a test failure.
@@ -1334,7 +1289,7 @@ public abstract class HttpWagonTestCase extends StreamingWagonTestCase {
             Repository testRepository = new Repository("id", getRepositoryUrl(server));
 
             File sourceFile = new File(localRepositoryPath, "test-secured-resource-exists");
-            FileUtils.fileWrite(sourceFile.getAbsolutePath(), "top secret");
+            Files.write(sourceFile.toPath().toAbsolutePath(), "top secret".getBytes(StandardCharsets.US_ASCII));
 
             wagon.connect(testRepository, authInfo);
 
@@ -1479,7 +1434,7 @@ public abstract class HttpWagonTestCase extends StreamingWagonTestCase {
 
             File tempFile = File.createTempFile("wagon", "tmp");
             tempFile.deleteOnExit();
-            FileUtils.fileWrite(tempFile.getAbsolutePath(), "content");
+            Files.write(tempFile.toPath().toAbsolutePath(), "content".getBytes(StandardCharsets.US_ASCII));
 
             try {
                 wagon.put(tempFile, "resource");
@@ -1507,7 +1462,7 @@ public abstract class HttpWagonTestCase extends StreamingWagonTestCase {
 
         File tempFile = File.createTempFile("wagon", "tmp");
         tempFile.deleteOnExit();
-        FileUtils.fileWrite(tempFile.getAbsolutePath(), "content");
+        Files.write(tempFile.toPath().toAbsolutePath(), "content".getBytes(StandardCharsets.US_ASCII));
 
         String baseUrl = getRepositoryUrl(server);
         String resourceName = "resource";
@@ -1587,7 +1542,8 @@ public abstract class HttpWagonTestCase extends StreamingWagonTestCase {
 
                 File tempFile = File.createTempFile("wagon", "tmp");
                 tempFile.deleteOnExit();
-                FileUtils.fileWrite(tempFile.getAbsolutePath(), "put top secret");
+                byte[] content = "put top secret".getBytes(StandardCharsets.US_ASCII);
+                Files.write(tempFile.toPath().toAbsolutePath(), content);
 
                 try {
                     wagon.put(tempFile, "test-secured-put-resource");
@@ -1595,7 +1551,8 @@ public abstract class HttpWagonTestCase extends StreamingWagonTestCase {
                     tempFile.delete();
                 }
 
-                assertEquals("put top secret", FileUtils.fileRead(sourceFile.getAbsolutePath()));
+                assertArrayEquals(
+                        content, Files.readAllBytes(sourceFile.toPath().toAbsolutePath()));
             }
         } finally {
             wagon.disconnect();
@@ -1654,16 +1611,17 @@ public abstract class HttpWagonTestCase extends StreamingWagonTestCase {
 
                 File tempFile = File.createTempFile("wagon", "tmp");
                 tempFile.deleteOnExit();
-                String content = "put top secret";
-                FileUtils.fileWrite(tempFile.getAbsolutePath(), content);
+                byte[] content = "put top secret".getBytes(StandardCharsets.UTF_8);
+                Files.write(tempFile.toPath().toAbsolutePath(), content);
 
                 try (FileInputStream fileInputStream = new FileInputStream(tempFile)) {
-                    wagon.putFromStream(fileInputStream, "test-secured-put-resource", content.length(), -1);
+                    wagon.putFromStream(fileInputStream, "test-secured-put-resource", content.length, -1);
                 } finally {
                     tempFile.delete();
                 }
 
-                assertEquals(content, FileUtils.fileRead(sourceFile.getAbsolutePath()));
+                assertArrayEquals(
+                        content, Files.readAllBytes(sourceFile.toPath().toAbsolutePath()));
             }
         } finally {
             wagon.disconnect();

--- a/wagon-providers/wagon-ftp/src/test/java/org/apache/maven/wagon/providers/ftp/FtpWagonTest.java
+++ b/wagon-providers/wagon-ftp/src/test/java/org/apache/maven/wagon/providers/ftp/FtpWagonTest.java
@@ -42,7 +42,7 @@ import org.apache.maven.wagon.resource.Resource;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.fail;
 
 /**
@@ -151,7 +151,7 @@ public class FtpWagonTest extends StreamingWagonTestCase {
             getWagon().connect(new Repository("id", getTestRepositoryUrl()), authenticationInfo);
             fail();
         } catch (AuthenticationException e) {
-            assertTrue(true);
+            assertNotNull(e.getMessage());
         }
     }
 

--- a/wagon-tcks/wagon-tck-http/src/main/java/org/apache/maven/wagon/tck/http/Assertions.java
+++ b/wagon-tcks/wagon-tck-http/src/main/java/org/apache/maven/wagon/tck/http/Assertions.java
@@ -23,6 +23,7 @@ import javax.servlet.http.HttpServletResponse;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.file.Files;
 
 import org.apache.maven.wagon.ResourceDoesNotExistException;
 import org.apache.maven.wagon.TransferFailedException;
@@ -33,14 +34,10 @@ import org.codehaus.plexus.util.IOUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static org.codehaus.plexus.util.FileUtils.fileRead;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-/**
- *
- */
 public final class Assertions {
 
     public static final int NO_RESPONSE_STATUS_CODE = -1;
@@ -51,7 +48,7 @@ public final class Assertions {
             final String resourceBase, final String resourceName, final File output, final String whyWouldItFail)
             throws IOException {
         String content = readResource(resourceBase, resourceName);
-        String test = fileRead(output);
+        String test = new String(Files.readAllBytes(output.toPath()));
 
         assertEquals(content, test, whyWouldItFail);
     }


### PR DESCRIPTION
These test classes drifted from `master`, which modernised them in passing: try-with-resources
instead of `IOUtil.close` in a `finally`, `java.nio.file.Files` instead of `plexus-util`
`FileUtils`, and a `conents` typo. This takes master's versions so the two lines stop diverging
in files that every provider migration has to touch.

Two files that also differ are deliberately left alone. `HttpWagonTests` is a published TCK
class and master removed `getConfigurator()`, `getRepo()`, `getTmpfiles()` and
`getPortPropertyValue()` from it — that is a 4.0 API drop, not drift, and it should not reach a
patch line. In `wagon-webdav-jackrabbit/pom.xml` the only difference beyond the version is a
comment master shortened, where this line's longer wording says more.

One change is not cosmetic: `FtpWagonTest` had `assertTrue(true)` in a catch block, which
asserts nothing, and master replaced it with `assertNotNull(e.getMessage())`. That test now
checks something it did not check before.

Verified: per-class `<testcase>` counts in the surefire XML are unchanged against `321d4603`
across all 30 test classes, with no new errors, failures or skips.

*This change was created with AI assistance.*
