### PR TITLE
Remove the dead JUnit 4 build configuration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -205,7 +205,7 @@ under the License.
         <version>1.5.1</version>
       </dependency>
       <!--
-       | The Plexus shim: org.eclipse.sisu.plexus supplies PlexusContainer and PlexusTestCase,
+       | The Plexus shim: org.eclipse.sisu.plexus supplies PlexusContainer,
        | and understands both META-INF/plexus/components.xml and JSR-330 @Named beans.
        | Its version is managed by maven-parent. Guice is "provided" in the sisu POM,
        | so it has to be declared here explicitly.

--- a/src/site/markdown/developer-guide.md
+++ b/src/site/markdown/developer-guide.md
@@ -225,20 +225,21 @@ for the largest example of this in the project.
 
 `wagon-provider-test` contains abstract test cases that exercise a provider through
 the public API against a real endpoint that you set up. It is a `compile`-scope
-artifact that drags in JUnit 3-style `PlexusTestCase`, Mockito and Jetty; the
+artifact that drags in JUnit 5, `plexus-testing`, Mockito and Jetty; the
 `wagon-providers` parent POM already declares it at `test` scope for every provider
 module.
 
 ### `WagonTestCase`
 
-`WagonTestCase extends PlexusTestCase`. Two abstract methods:
+`WagonTestCase` is annotated `@PlexusTest` and implements `PlexusTestConfiguration`,
+which is what gives it a container. Two abstract methods:
 
 ```java
 protected abstract String getProtocol();          // the role hint, e.g. "file"
 protected abstract String getTestRepositoryUrl(); // where the tests should write
 ```
 
-`getWagon()` looks the provider up with `lookup(Wagon.ROLE, getProtocol())` and
+`getWagon()` looks the provider up with `container.lookup(Wagon.class, getProtocol())` and
 attaches an `observers.Debug` as both session and transfer listener, so a failing run
 prints a transcript.
 

--- a/wagon-providers/pom.xml
+++ b/wagon-providers/pom.xml
@@ -78,12 +78,6 @@ under the License.
       <groupId>org.apache.maven.wagon</groupId>
       <artifactId>wagon-provider-test</artifactId>
       <scope>test</scope>
-      <exclusions>
-        <exclusion>
-          <groupId>junit</groupId>
-          <artifactId>junit</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
   </dependencies>
 </project>

--- a/wagon-providers/wagon-http-lightweight/pom.xml
+++ b/wagon-providers/wagon-http-lightweight/pom.xml
@@ -49,12 +49,6 @@ under the License.
       <artifactId>wagon-tck-http</artifactId>
       <version>${project.version}</version>
       <scope>test</scope>
-      <exclusions>
-        <exclusion>
-          <groupId>junit</groupId>
-          <artifactId>junit</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.codehaus.plexus</groupId>

--- a/wagon-providers/wagon-http/pom.xml
+++ b/wagon-providers/wagon-http/pom.xml
@@ -108,12 +108,6 @@ under the License.
       <artifactId>wagon-tck-http</artifactId>
       <version>${project.version}</version>
       <scope>test</scope>
-      <exclusions>
-        <exclusion>
-          <groupId>junit</groupId>
-          <artifactId>junit</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
 
   </dependencies>

--- a/wagon-providers/wagon-scm/pom.xml
+++ b/wagon-providers/wagon-scm/pom.xml
@@ -48,7 +48,9 @@ under the License.
       <exclusions>
         <!--
          | Drags in plexus-container-default 1.0-alpha-9, which collides with the Plexus shim
-         | (two copies of PlexusContainer/PlexusTestCase on the test classpath).
+         | (two copies of PlexusContainer and PlexusTestCase on the test classpath, with the
+         | 2005 alpha-9 copy winning). It also drags in classworlds 1.1-alpha-2 and junit 4.13.2
+         | at runtime scope, which would leak JUnit into this provider's consumers.
         -->
         <exclusion>
           <groupId>org.codehaus.plexus</groupId>

--- a/wagon-providers/wagon-ssh-common-test/pom.xml
+++ b/wagon-providers/wagon-ssh-common-test/pom.xml
@@ -60,12 +60,6 @@ under the License.
     <dependency>
       <groupId>org.apache.maven.wagon</groupId>
       <artifactId>wagon-provider-test</artifactId>
-      <exclusions>
-        <exclusion>
-          <groupId>junit</groupId>
-          <artifactId>junit</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.apache.maven.wagon</groupId>

--- a/wagon-providers/wagon-ssh/src/test/java/org/apache/maven/wagon/providers/ssh/jsch/TestPrompter.java
+++ b/wagon-providers/wagon-ssh/src/test/java/org/apache/maven/wagon/providers/ssh/jsch/TestPrompter.java
@@ -28,7 +28,7 @@ import org.codehaus.plexus.components.interactivity.PrompterException;
  * {@code src/test/resources/META-INF/plexus/components.xml}.
  * <p>
  * {@code plexus-interactivity-api} stopped shipping a {@code META-INF/plexus/components.xml} in 1.3, so its
- * {@code DefaultPrompter} is invisible to the {@code plexus-container-default} that {@code PlexusTestCase} runs;
+ * {@code DefaultPrompter} is invisible to the {@code plexus-container-default} the tests run;
  * without a replacement every {@code lookup( Wagon.ROLE, "scp" )} fails because {@code ConsoleInteractiveUserInfo}
  * and {@code PrompterUIKeyboardInteractive} both require one.
  * <p>

--- a/wagon-providers/wagon-ssh/src/test/resources/META-INF/plexus/components.xml
+++ b/wagon-providers/wagon-ssh/src/test/resources/META-INF/plexus/components.xml
@@ -22,7 +22,7 @@
   plexus-interactivity-api dropped its own META-INF/plexus/components.xml in 1.3 and only ships a sisu index, so
   plexus-container-default cannot see DefaultPrompter (which in any case now takes its collaborators through a
   constructor, which plexus-container-default cannot satisfy). Maven itself runs on sisu and is unaffected; only
-  the PlexusTestCase-based tests here need this descriptor.
+  the tests here need this descriptor.
 -->
 <component-set>
   <components>


### PR DESCRIPTION
Follows #939, which landed before this part was pushed.

The four `junit:junit` exclusions no longer exclude anything. `wagon-provider-test` stopped
declaring `junit` in #937, and removing all four leaves the reactor resolving exactly the same
single `junit:junit:4.13.2:test`, in `wagon-scm`, that it resolves today.

That one is why the managed `junit:junit` version stays. It is not a dependency of ours:
`maven-scm-provider-gittest` brings `maven-scm-test`, which brings `junit`, and the managed
version is what holds it at 4.13.2. Without it `wagon-scm` drops to 4.12.

The `plexus-container-default` exclusion in `wagon-scm` is untouched and its comment now says
what it actually does. `maven-scm-manager-plexus` declares that artifact unversioned and
`maven-scm` 1.11.1 manages it at 1.0-alpha-9, which ships the same `PlexusContainer`,
`DefaultPlexusContainer` and `PlexusTestCase` class names as `org.eclipse.sisu.plexus`, declared
first so the 2005 copy would win. It also drags in `classworlds` 1.1-alpha-2 and `junit` at
runtime scope, which would leak JUnit into this provider's consumers.

Three comments still described the tests as PlexusTestCase-based, and the developer guide still
said `wagon-provider-test` drags in JUnit 3-style `PlexusTestCase`, that `WagonTestCase extends
PlexusTestCase`, and that `getWagon()` calls `lookup(Wagon.ROLE, getProtocol())`. None of that
has been true since #937.

The three javadoc lines in `WagonTestCase` that name `PlexusTestCase` stay. They record why
`getTestFile`, `getTestPath` and `getBasedir` exist as delegating methods, which is what stops
someone removing them and breaking consumers that inherit them.

Verified: `dependency:tree` over the whole reactor with and without the four exclusions is
identical, and per-class `<testcase>` counts are unchanged across all 30 test classes.

*This change was created with AI assistance.*
