### PR TITLE
[3.x] Fix HTTP auth scope, preemptive PUT, timeout merge semantics, and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ There are some guidelines which will make applying PRs easier for us:
     If you feel the source code should be reformatted, create a separate PR for this change.
   + Check for unnecessary whitespace with `git diff --check` before committing.
 + Make sure you have added the necessary tests (JUnit/IT) for your changes.
-+ Run all the tests with `mvn -Prun-its verify` to assure nothing else was accidentally broken.
++ Run all the tests with `mvn verify` (or `mvn verify -Dssh-tests -Dssh-embedded=true` to include SSH tests) to assure nothing else was accidentally broken.
 + Submit a pull request to the repository in the Apache organization.
 
 If you plan to contribute on a regular basis, please consider filing a [contributor license agreement][cla].

--- a/wagon-providers/wagon-http-shared/src/main/java/org/apache/maven/wagon/shared/http/AbstractHttpClientWagon.java
+++ b/wagon-providers/wagon-http-shared/src/main/java/org/apache/maven/wagon/shared/http/AbstractHttpClientWagon.java
@@ -687,19 +687,6 @@ public abstract class AbstractHttpClientWagon extends StreamWagon {
             fireTransferError(resource, e, TransferEvent.REQUEST_PUT);
         }
 
-        // preemptive for put
-        // TODO: is it a good idea, though? 'Expect-continue' handshake would serve much better
-
-        // FIXME Perform only when preemptive has been configured
-        Repository repo = getRepository();
-        HttpHost targetHost = new HttpHost(repo.getHost(), repo.getPort(), repo.getProtocol());
-        AuthScope targetScope = getBasicAuthScope().getScope(targetHost);
-
-        if (credentialsProvider.getCredentials(targetScope) != null) {
-            BasicScheme targetAuth = new BasicScheme(StandardCharsets.UTF_8);
-            authCache.put(targetHost, targetAuth);
-        }
-
         HttpPut putMethod = new HttpPut(url);
 
         firePutStarted(resource, source);

--- a/wagon-providers/wagon-http-shared/src/main/java/org/apache/maven/wagon/shared/http/BasicAuthScope.java
+++ b/wagon-providers/wagon-http-shared/src/main/java/org/apache/maven/wagon/shared/http/BasicAuthScope.java
@@ -67,15 +67,11 @@ public class BasicAuthScope {
      * them: {@code basicAuth} for the target host and {@code proxyAuth} for the proxy, settable
      * through {@code setBasicAuthScope} and {@code setProxyBasicAuthScope} respectively.
      * <p>
-     * A non-null {@link #getHost() host} or {@link #getPort() port} replaces the value passed
-     * in; the literal string {@code "ANY"} selects {@link AuthScope#ANY_HOST} or
-     * {@link AuthScope#ANY_PORT}. A passed-in port of {@code -1} also yields
-     * {@link AuthScope#ANY_PORT}. When host, port and realm are all {@code "ANY"},
+     * A non-null {@link #getHost() host}, {@link #getPort() port}, or {@link #getRealm() realm} replaces the value passed
+     * in; the literal string {@code "ANY"} selects {@link AuthScope#ANY_HOST}, {@link AuthScope#ANY_PORT}, or
+     * {@link AuthScope#ANY_REALM}. A passed-in port of {@code -1} also yields {@link AuthScope#ANY_PORT}. Leaving
+     * realm unset yields {@link AuthScope#ANY_REALM}. When host, port and realm are all {@code "ANY"},
      * {@link AuthScope#ANY} is returned.
-     * <p>
-     * {@link #getRealm() realm} does not follow that pattern. Leaving it unset yields
-     * {@link AuthScope#ANY_REALM}; any non-null value is used verbatim as the realm to match,
-     * including {@code "ANY"} itself unless host and port are {@code "ANY"} as well.
      *
      * @param host the host to scope credentials to, before any override is applied
      * @param port the port to scope credentials to, before any override is applied; -1 means
@@ -117,7 +113,7 @@ public class BasicAuthScope {
             if ("ANY".compareTo(getRealm()) != 0) {
                 scopeRealm = getRealm();
             } else {
-                scopeRealm = getRealm();
+                scopeRealm = AuthScope.ANY_REALM;
             }
         }
 

--- a/wagon-providers/wagon-http-shared/src/main/java/org/apache/maven/wagon/shared/http/ConfigurationUtils.java
+++ b/wagon-providers/wagon-http-shared/src/main/java/org/apache/maven/wagon/shared/http/ConfigurationUtils.java
@@ -30,7 +30,6 @@ import org.apache.http.Header;
 import org.apache.http.HttpHost;
 import org.apache.http.client.config.RequestConfig;
 import org.apache.http.message.BasicHeader;
-import org.apache.maven.wagon.Wagon;
 
 /**
  * Configuration helper class
@@ -58,8 +57,12 @@ public class ConfigurationUtils {
     private static final String COERCE_PATTERN = "%(\\w+),(.+)";
 
     public static void copyConfig(HttpMethodConfiguration config, RequestConfig.Builder builder) {
-        builder.setConnectTimeout(config.getConnectionTimeout());
-        builder.setSocketTimeout(config.getReadTimeout());
+        if (config.isConnectionTimeoutSet()) {
+            builder.setConnectTimeout(config.getConnectionTimeout());
+        }
+        if (config.isReadTimeoutSet()) {
+            builder.setSocketTimeout(config.getReadTimeout());
+        }
 
         Properties params = config.getParams();
         if (params != null) {
@@ -152,11 +155,11 @@ public class ConfigurationUtils {
         } else {
             HttpMethodConfiguration result = base.copy();
 
-            if (local.getConnectionTimeout() != Wagon.DEFAULT_CONNECTION_TIMEOUT) {
+            if (local.isConnectionTimeoutSet()) {
                 result.setConnectionTimeout(local.getConnectionTimeout());
             }
 
-            if (local.getReadTimeout() != Wagon.DEFAULT_READ_TIMEOUT) {
+            if (local.isReadTimeoutSet()) {
                 result.setReadTimeout(local.getReadTimeout());
             }
 
@@ -170,6 +173,10 @@ public class ConfigurationUtils {
 
             if (local.getUseDefaultHeaders() != null) {
                 result.setUseDefaultHeaders(local.isUseDefaultHeaders());
+            }
+
+            if (local.isUsePreemptiveSet()) {
+                result.setUsePreemptive(local.isUsePreemptive());
             }
 
             return result;

--- a/wagon-providers/wagon-http-shared/src/main/java/org/apache/maven/wagon/shared/http/HttpMethodConfiguration.java
+++ b/wagon-providers/wagon-http-shared/src/main/java/org/apache/maven/wagon/shared/http/HttpMethodConfiguration.java
@@ -36,12 +36,11 @@ public class HttpMethodConfiguration {
 
     private Properties params = new Properties();
 
-    private int connectionTimeout = Wagon.DEFAULT_CONNECTION_TIMEOUT;
+    private Integer connectionTimeout;
 
-    private int readTimeout =
-            Integer.parseInt(System.getProperty("maven.wagon.rto", Integer.toString(Wagon.DEFAULT_READ_TIMEOUT)));
+    private Integer readTimeout;
 
-    private boolean usePreemptive = false;
+    private Boolean usePreemptive;
 
     public boolean isUseDefaultHeaders() {
         return useDefaultHeaders == null || useDefaultHeaders.booleanValue();
@@ -85,7 +84,7 @@ public class HttpMethodConfiguration {
     }
 
     public int getConnectionTimeout() {
-        return connectionTimeout;
+        return connectionTimeout != null ? connectionTimeout : Wagon.DEFAULT_CONNECTION_TIMEOUT;
     }
 
     public HttpMethodConfiguration setConnectionTimeout(int connectionTimeout) {
@@ -93,8 +92,14 @@ public class HttpMethodConfiguration {
         return this;
     }
 
+    public boolean isConnectionTimeoutSet() {
+        return connectionTimeout != null;
+    }
+
     public int getReadTimeout() {
-        return readTimeout;
+        return readTimeout != null
+                ? readTimeout
+                : Integer.parseInt(System.getProperty("maven.wagon.rto", Integer.toString(Wagon.DEFAULT_READ_TIMEOUT)));
     }
 
     public HttpMethodConfiguration setReadTimeout(int readTimeout) {
@@ -102,13 +107,25 @@ public class HttpMethodConfiguration {
         return this;
     }
 
+    public boolean isReadTimeoutSet() {
+        return readTimeout != null;
+    }
+
     public boolean isUsePreemptive() {
-        return usePreemptive;
+        return Boolean.TRUE.equals(usePreemptive);
     }
 
     public HttpMethodConfiguration setUsePreemptive(boolean usePreemptive) {
-        this.usePreemptive = usePreemptive;
+        this.usePreemptive = Boolean.valueOf(usePreemptive);
         return this;
+    }
+
+    public Boolean getUsePreemptive() {
+        return usePreemptive;
+    }
+
+    public boolean isUsePreemptiveSet() {
+        return usePreemptive != null;
     }
 
     public Header[] asRequestHeaders() {
@@ -133,8 +150,12 @@ public class HttpMethodConfiguration {
     HttpMethodConfiguration copy() {
         HttpMethodConfiguration copy = new HttpMethodConfiguration();
 
-        copy.setConnectionTimeout(getConnectionTimeout());
-        copy.setReadTimeout(getReadTimeout());
+        if (connectionTimeout != null) {
+            copy.setConnectionTimeout(connectionTimeout);
+        }
+        if (readTimeout != null) {
+            copy.setReadTimeout(readTimeout);
+        }
         if (getHeaders() != null) {
             copy.getHeaders().putAll(getHeaders());
         }
@@ -143,7 +164,13 @@ public class HttpMethodConfiguration {
             copy.getParams().putAll(getParams());
         }
 
-        copy.setUseDefaultHeaders(isUseDefaultHeaders());
+        if (useDefaultHeaders != null) {
+            copy.setUseDefaultHeaders(useDefaultHeaders);
+        }
+
+        if (usePreemptive != null) {
+            copy.setUsePreemptive(usePreemptive);
+        }
 
         return copy;
     }

--- a/wagon-providers/wagon-http-shared/src/test/java/org/apache/maven/wagon/shared/http/ConfigurationUtilsTest.java
+++ b/wagon-providers/wagon-http-shared/src/test/java/org/apache/maven/wagon/shared/http/ConfigurationUtilsTest.java
@@ -1,0 +1,135 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.wagon.shared.http;
+
+import org.apache.http.client.config.RequestConfig;
+import org.apache.maven.wagon.Wagon;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class ConfigurationUtilsTest {
+
+    @Test
+    public void testCopyConfigDoesNotOverwriteBuilderTimeoutsWhenUnset() {
+        RequestConfig.Builder builder = RequestConfig.custom();
+        builder.setConnectTimeout(12345);
+        builder.setSocketTimeout(54321);
+
+        HttpMethodConfiguration config = new HttpMethodConfiguration();
+        assertFalse(config.isConnectionTimeoutSet());
+        assertFalse(config.isReadTimeoutSet());
+
+        ConfigurationUtils.copyConfig(config, builder);
+
+        RequestConfig requestConfig = builder.build();
+        assertEquals(12345, requestConfig.getConnectTimeout());
+        assertEquals(54321, requestConfig.getSocketTimeout());
+    }
+
+    @Test
+    public void testCopyConfigOverwritesBuilderTimeoutsWhenSet() {
+        RequestConfig.Builder builder = RequestConfig.custom();
+        builder.setConnectTimeout(12345);
+        builder.setSocketTimeout(54321);
+
+        HttpMethodConfiguration config = new HttpMethodConfiguration();
+        config.setConnectionTimeout(999);
+        config.setReadTimeout(888);
+        assertTrue(config.isConnectionTimeoutSet());
+        assertTrue(config.isReadTimeoutSet());
+
+        ConfigurationUtils.copyConfig(config, builder);
+
+        RequestConfig requestConfig = builder.build();
+        assertEquals(999, requestConfig.getConnectTimeout());
+        assertEquals(888, requestConfig.getSocketTimeout());
+    }
+
+    @Test
+    public void testMergePreservesUsePreemptiveFromBase() {
+        HttpMethodConfiguration base = new HttpMethodConfiguration();
+        base.setUsePreemptive(true);
+
+        HttpMethodConfiguration local = new HttpMethodConfiguration();
+        assertFalse(local.isUsePreemptiveSet());
+
+        HttpMethodConfiguration merged = ConfigurationUtils.merge(base, local);
+        assertTrue(merged.isUsePreemptive());
+    }
+
+    @Test
+    public void testMergeOverridesUsePreemptiveFromLocal() {
+        HttpMethodConfiguration base = new HttpMethodConfiguration();
+        base.setUsePreemptive(true);
+
+        HttpMethodConfiguration local = new HttpMethodConfiguration();
+        local.setUsePreemptive(false);
+        assertTrue(local.isUsePreemptiveSet());
+
+        HttpMethodConfiguration merged = ConfigurationUtils.merge(base, local);
+        assertFalse(merged.isUsePreemptive());
+    }
+
+    @Test
+    public void testMergePreservesTimeoutsFromBase() {
+        HttpMethodConfiguration base = new HttpMethodConfiguration();
+        base.setConnectionTimeout(10000);
+        base.setReadTimeout(20000);
+
+        HttpMethodConfiguration local = new HttpMethodConfiguration();
+
+        HttpMethodConfiguration merged = ConfigurationUtils.merge(base, local);
+        assertEquals(10000, merged.getConnectionTimeout());
+        assertEquals(20000, merged.getReadTimeout());
+    }
+
+    @Test
+    public void testMergeOverridesTimeoutsEvenIfDefaultValue() {
+        HttpMethodConfiguration base = new HttpMethodConfiguration();
+        base.setConnectionTimeout(99999);
+        base.setReadTimeout(88888);
+
+        HttpMethodConfiguration local = new HttpMethodConfiguration();
+        local.setConnectionTimeout(Wagon.DEFAULT_CONNECTION_TIMEOUT);
+        local.setReadTimeout(Wagon.DEFAULT_READ_TIMEOUT);
+
+        HttpMethodConfiguration merged = ConfigurationUtils.merge(base, local);
+        assertEquals(Wagon.DEFAULT_CONNECTION_TIMEOUT, merged.getConnectionTimeout());
+        assertEquals(Wagon.DEFAULT_READ_TIMEOUT, merged.getReadTimeout());
+    }
+
+    @Test
+    public void testCopyClonesPreemptiveAndTimeouts() {
+        HttpMethodConfiguration config = new HttpMethodConfiguration();
+        config.setConnectionTimeout(111);
+        config.setReadTimeout(222);
+        config.setUsePreemptive(true);
+
+        HttpMethodConfiguration copy = config.copy();
+        assertTrue(copy.isConnectionTimeoutSet());
+        assertEquals(111, copy.getConnectionTimeout());
+        assertTrue(copy.isReadTimeoutSet());
+        assertEquals(222, copy.getReadTimeout());
+        assertTrue(copy.isUsePreemptiveSet());
+        assertTrue(copy.isUsePreemptive());
+    }
+}

--- a/wagon-providers/wagon-http/src/test/java/org/apache/maven/wagon/providers/http/BasicAuthScopeTest.java
+++ b/wagon-providers/wagon-http/src/test/java/org/apache/maven/wagon/providers/http/BasicAuthScopeTest.java
@@ -84,6 +84,19 @@ public class BasicAuthScopeTest {
     }
 
     /**
+     * Test AuthScope override with realm="ANY" only, which should result in AuthScope.ANY_REALM.
+     */
+    @Test
+    public void testGetScopeRealmAnyOnly() {
+        BasicAuthScope scope = new BasicAuthScope();
+        scope.setRealm("ANY");
+        AuthScope authScope = scope.getScope("original.host.com", 3456);
+        assertEquals("original.host.com", authScope.getHost());
+        assertEquals(3456, authScope.getPort());
+        assertEquals(AuthScope.ANY_REALM, authScope.getRealm());
+    }
+
+    /**
      * Test AuthScope where original port is -1, which should result in ANY
      */
     @Test

--- a/wagon-providers/wagon-http/src/test/java/org/apache/maven/wagon/providers/http/HttpWagonTest.java
+++ b/wagon-providers/wagon-http/src/test/java/org/apache/maven/wagon/providers/http/HttpWagonTest.java
@@ -49,7 +49,7 @@ public class HttpWagonTest extends HttpWagonTestCase {
 
     @Override
     protected boolean supportPreemptiveAuthenticationPut() {
-        return true;
+        return false;
     }
 
     @Override


### PR DESCRIPTION
Consolidated quick-win bugfixes for HTTP configuration, authentication handling, and developer documentation on the 3.x line:

- **#907**: Correct `README.md` line 62 test instruction from non-existent `mvn -Prun-its verify` to `mvn verify` (and document `-Dssh-tests -Dssh-embedded=true`).
- **#910**: Map `<realm>ANY</realm>` to `AuthScope.ANY_REALM` in `BasicAuthScope.java` instead of the literal string `"ANY"`, matching the host and port handling.
- **#906**: Make `usePreemptive` a `Boolean` in `HttpMethodConfiguration` so that `copy()` and `ConfigurationUtils.merge()` preserve it across method blocks and `<all>`.
- **#908**: Make timeouts nullable in `HttpMethodConfiguration` and check `isConnectionTimeoutSet()` / `isReadTimeoutSet()` so `ConfigurationUtils.copyConfig()` does not discard timeouts configured on `Wagon`, and `merge()` allows overriding timeouts back to default values. Added comprehensive `ConfigurationUtilsTest`.
- **#909**: Remove unconditional priming of the auth cache in `AbstractHttpClientWagon.put()` so that PUT requests only authenticate preemptively when configured, and update `HttpWagonTest` accordingly.

Fixes #906
Fixes #907
Fixes #908
Fixes #909
Fixes #910