### PR TITLE
[wagon-3.x] Backport repository, issue templates, and CI configuration from master

### DIFF
--- a/.github/ISSUE_TEMPLATE/BUG.yml
+++ b/.github/ISSUE_TEMPLATE/BUG.yml
@@ -1,42 +1,48 @@
-# 
+#
 #  Licensed to the Apache Software Foundation (ASF) under one or more
 #  contributor license agreements.  See the NOTICE file distributed with
 #  this work for additional information regarding copyright ownership.
 #  The ASF licenses this file to You under the Apache License, Version 2.0
 #  (the "License"); you may not use this file except in compliance with
 #  the License.  You may obtain a copy of the License at
-# 
+#
 #       http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 #  Unless required by applicable law or agreed to in writing, software
 #  distributed under the License is distributed on an "AS IS" BASIS,
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 #
-# see https://s.apache.org/asfyaml
-github:
-  description: "Apache Maven Wagon"
-  homepage: https://maven.apache.org/wagon/
-  labels:
-    - java
-    - build-management
-    - maven-plugins
-    - maven-wagon
-    - maven
-  protected_branches:
-    master: { }
-    wagon-3.x: { }
-    wagon-1.x: { }
-  pull_requests:
-    del_branch_on_merge: true
-  enabled_merge_buttons:
-    squash: true
-    merge: false
-    rebase: true
-  features:
-    issues: true
-notifications:
-  commits: commits@maven.apache.org
-  #issues: issues@maven.apache.org
-  #pullrequests: issues@maven.apache.org
+
+# https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-githubs-form-schema
+
+name: Bug Report
+description: File a bug report
+labels: ["bug"]
+
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to fill out this bug report.     
+
+        Simple fixes in single PRs do not require issues. 
+  
+        **Do you use the latest project version?**
+
+  - type: input
+    id: version
+    attributes:
+      label: Affected version
+    validations:
+      required: true
+
+  - type: textarea
+    id: message
+    attributes:
+      label: Bug description
+    validations:
+      required: true
+
+

--- a/.github/ISSUE_TEMPLATE/FEATURE.yml
+++ b/.github/ISSUE_TEMPLATE/FEATURE.yml
@@ -1,42 +1,35 @@
-# 
+#
 #  Licensed to the Apache Software Foundation (ASF) under one or more
 #  contributor license agreements.  See the NOTICE file distributed with
 #  this work for additional information regarding copyright ownership.
 #  The ASF licenses this file to You under the Apache License, Version 2.0
 #  (the "License"); you may not use this file except in compliance with
 #  the License.  You may obtain a copy of the License at
-# 
+#
 #       http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 #  Unless required by applicable law or agreed to in writing, software
 #  distributed under the License is distributed on an "AS IS" BASIS,
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 #
-# see https://s.apache.org/asfyaml
-github:
-  description: "Apache Maven Wagon"
-  homepage: https://maven.apache.org/wagon/
-  labels:
-    - java
-    - build-management
-    - maven-plugins
-    - maven-wagon
-    - maven
-  protected_branches:
-    master: { }
-    wagon-3.x: { }
-    wagon-1.x: { }
-  pull_requests:
-    del_branch_on_merge: true
-  enabled_merge_buttons:
-    squash: true
-    merge: false
-    rebase: true
-  features:
-    issues: true
-notifications:
-  commits: commits@maven.apache.org
-  #issues: issues@maven.apache.org
-  #pullrequests: issues@maven.apache.org
+
+# https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-githubs-form-schema
+
+name: Feature request
+description: File a proposal for new feature, improvement
+labels: ["enhancement"]
+
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to fill out this new feature, improvement proposal.
+
+  - type: textarea
+    id: message
+    attributes:
+      label: New feature, improvement proposal
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,42 +1,27 @@
-# 
+#
 #  Licensed to the Apache Software Foundation (ASF) under one or more
 #  contributor license agreements.  See the NOTICE file distributed with
 #  this work for additional information regarding copyright ownership.
 #  The ASF licenses this file to You under the Apache License, Version 2.0
 #  (the "License"); you may not use this file except in compliance with
 #  the License.  You may obtain a copy of the License at
-# 
+#
 #       http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 #  Unless required by applicable law or agreed to in writing, software
 #  distributed under the License is distributed on an "AS IS" BASIS,
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 #
-# see https://s.apache.org/asfyaml
-github:
-  description: "Apache Maven Wagon"
-  homepage: https://maven.apache.org/wagon/
-  labels:
-    - java
-    - build-management
-    - maven-plugins
-    - maven-wagon
-    - maven
-  protected_branches:
-    master: { }
-    wagon-3.x: { }
-    wagon-1.x: { }
-  pull_requests:
-    del_branch_on_merge: true
-  enabled_merge_buttons:
-    squash: true
-    merge: false
-    rebase: true
-  features:
-    issues: true
-notifications:
-  commits: commits@maven.apache.org
-  #issues: issues@maven.apache.org
-  #pullrequests: issues@maven.apache.org
+
+# https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository#configuring-the-template-chooser
+
+blank_issues_enabled: false
+
+contact_links:
+
+  - name: Project Mailing Lists
+    url: https://maven.apache.org/mailing-lists.html
+    about: Please ask a question or discuss here
+

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -25,12 +25,23 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
-    target-branch: "wagon-1.x"
+    target-branch: "wagon-3.x"
     labels:
       - "mvn3"
+      - "dependencies"
+      - "java"
 
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "daily"
 
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    target-branch: "wagon-3.x"
+    labels:
+      - "mvn3"
+      - "dependencies"
+      - "github_actions"

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,23 @@
+Following this checklist to help us incorporate your
+contribution quickly and easily:
+
+- [ ] Your pull request should address just one issue, without pulling in other changes.
+- [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
+- [ ] Each commit in the pull request should have a meaningful subject line and body.
+  Note that commits might be squashed by a maintainer on merge.
+- [ ] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied.
+  This may not always be possible but is a best-practice.
+- [ ] Run `mvn verify` to make sure basic checks pass.
+  A more thorough check will be performed on your pull request automatically.
+- [ ] You have run the tests successfully (`mvn verify`).
+
+If your pull request is about ~20 lines of code you don't need to sign an
+[Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf) if you are unsure
+please ask on the developers list.
+
+To make clear that you license your contribution under
+the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
+you have to acknowledge this by using the following check-box.
+
+- [ ] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
+- [ ] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,28 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+name: Stale
+
+on:
+  schedule:
+    - cron: '20 20 * * *'
+  issue_comment:
+    types: [ 'created' ]
+
+jobs:
+  stale:
+    uses: 'apache/maven-gh-actions-shared/.github/workflows/stale.yml@v5'


### PR DESCRIPTION
Backport repository and CI configurations to the `wagon-3.x` maintenance branch:

- **`.asf.yaml`**: Add `protected_branches` (master, wagon-3.x, wagon-1.x), `del_branch_on_merge: true`, enable GitHub issues, and remove obsolete `autolink_jira: - WAGON`.
- **`.github/dependabot.yml`**: Target `wagon-3.x` branch for both Maven and GitHub Actions dependency ecosystems.
- **`.github/ISSUE_TEMPLATE/`**: Add `BUG.yml`, `FEATURE.yml`, and `config.yml` issue forms.
- **`.github/pull_request_template.md`**: Add standard PR checklist with contributor guidance.
- **`.github/workflows/stale.yml`**: Add scheduled stale issue/PR workflow.