### PR TITLE
[wagon-3.x] Introduce automatic module names for components

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -264,6 +264,17 @@ under the License.
       <plugins>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-jar-plugin</artifactId>
+          <configuration>
+            <archive>
+              <manifestEntries>
+                <Automatic-Module-Name>${wagon.automatic.module.name}</Automatic-Module-Name>
+              </manifestEntries>
+            </archive>
+          </configuration>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-surefire-plugin</artifactId>
           <configuration>
             <forkedProcessTimeoutInSeconds>800</forkedProcessTimeoutInSeconds>

--- a/wagon-provider-api/pom.xml
+++ b/wagon-provider-api/pom.xml
@@ -30,6 +30,10 @@ under the License.
   <name>Apache Maven Wagon :: API</name>
   <description>Maven Wagon API that defines the contract between different Wagon implementations</description>
 
+  <properties>
+    <wagon.automatic.module.name>org.apache.maven.wagon.provider.api</wagon.automatic.module.name>
+  </properties>
+
   <dependencies>
     <dependency>
       <groupId>org.junit.jupiter</groupId>

--- a/wagon-provider-test/pom.xml
+++ b/wagon-provider-test/pom.xml
@@ -30,6 +30,10 @@ under the License.
   <name>Apache Maven Wagon :: Provider Test</name>
   <description>Suite of tests for Wagon implementations</description>
 
+  <properties>
+    <wagon.automatic.module.name>org.apache.maven.wagon.provider.test</wagon.automatic.module.name>
+  </properties>
+
   <dependencies>
     <!-- WagonTestCase and CommandExecutorTestCase are published here and use @PlexusTest,
          so this is compile scope rather than test scope -->

--- a/wagon-providers/wagon-file/pom.xml
+++ b/wagon-providers/wagon-file/pom.xml
@@ -30,6 +30,10 @@ under the License.
   <name>Apache Maven Wagon :: Providers :: File Provider</name>
   <description>Wagon provider that gets and puts artifacts using file system protocol</description>
 
+  <properties>
+    <wagon.automatic.module.name>org.apache.maven.wagon.providers.file</wagon.automatic.module.name>
+  </properties>
+
   <dependencies>
     <dependency>
       <groupId>org.codehaus.plexus</groupId>

--- a/wagon-providers/wagon-ftp/pom.xml
+++ b/wagon-providers/wagon-ftp/pom.xml
@@ -30,6 +30,10 @@ under the License.
   <name>Apache Maven Wagon :: Providers :: FTP Provider</name>
   <description>Wagon provider that gets and puts artifacts from and to remote server using FTP protocol</description>
 
+  <properties>
+    <wagon.automatic.module.name>org.apache.maven.wagon.providers.ftp</wagon.automatic.module.name>
+  </properties>
+
   <dependencies>
     <dependency>
       <groupId>commons-net</groupId>

--- a/wagon-providers/wagon-http-lightweight/pom.xml
+++ b/wagon-providers/wagon-http-lightweight/pom.xml
@@ -30,6 +30,10 @@ under the License.
   <name>Apache Maven Wagon :: Providers :: Lightweight HTTP Provider</name>
   <description>Wagon provider that gets and puts artifacts through http using standard Java library</description>
 
+  <properties>
+    <wagon.automatic.module.name>org.apache.maven.wagon.providers.http.lightweight</wagon.automatic.module.name>
+  </properties>
+
   <dependencies>
     <!-- TckTest aggregates the TCK suites, now through the JUnit Platform -->
     <dependency>

--- a/wagon-providers/wagon-http-shared/pom.xml
+++ b/wagon-providers/wagon-http-shared/pom.xml
@@ -30,6 +30,10 @@ under the License.
   <name>Apache Maven Wagon :: Providers :: HTTP Shared Library</name>
   <description>Shared Library for wagon providers supporting HTTP.</description>
 
+  <properties>
+    <wagon.automatic.module.name>org.apache.maven.wagon.providers.http.shared</wagon.automatic.module.name>
+  </properties>
+
   <dependencies>
     <dependency>
       <groupId>org.apache.httpcomponents</groupId>

--- a/wagon-providers/wagon-http/pom.xml
+++ b/wagon-providers/wagon-http/pom.xml
@@ -30,6 +30,10 @@ under the License.
   <name>Apache Maven Wagon :: Providers :: HTTP Provider</name>
   <description>Wagon provider that gets and puts artifacts through HTTP(S) using Apache HttpClient-4.x.</description>
 
+  <properties>
+    <wagon.automatic.module.name>org.apache.maven.wagon.providers.http</wagon.automatic.module.name>
+  </properties>
+
   <dependencies>
     <!-- TckTest aggregates the TCK suites, now through the JUnit Platform -->
     <dependency>

--- a/wagon-providers/wagon-scm/pom.xml
+++ b/wagon-providers/wagon-scm/pom.xml
@@ -31,6 +31,7 @@ under the License.
   <description>Wagon provider that gets and puts artifacts using a Source Control Management system</description>
 
   <properties>
+    <wagon.automatic.module.name>org.apache.maven.wagon.providers.scm</wagon.automatic.module.name>
     <mavenScmVersion>2.2.1</mavenScmVersion>
   </properties>
 

--- a/wagon-providers/wagon-ssh-common-test/pom.xml
+++ b/wagon-providers/wagon-ssh-common-test/pom.xml
@@ -30,6 +30,7 @@ under the License.
   <name>Apache Maven Wagon :: Providers :: SSH Common Tests</name>
 
   <properties>
+    <wagon.automatic.module.name>org.apache.maven.wagon.providers.ssh.common.test</wagon.automatic.module.name>
     <sshdVersion>2.19.0</sshdVersion>
   </properties>
   <dependencies>

--- a/wagon-providers/wagon-ssh-common/pom.xml
+++ b/wagon-providers/wagon-ssh-common/pom.xml
@@ -29,6 +29,10 @@ under the License.
   <artifactId>wagon-ssh-common</artifactId>
   <name>Apache Maven Wagon :: Providers :: SSH Common Library</name>
 
+  <properties>
+    <wagon.automatic.module.name>org.apache.maven.wagon.providers.ssh.common</wagon.automatic.module.name>
+  </properties>
+
   <dependencies>
     <dependency>
       <groupId>org.codehaus.plexus</groupId>

--- a/wagon-providers/wagon-ssh-external/pom.xml
+++ b/wagon-providers/wagon-ssh-external/pom.xml
@@ -31,6 +31,7 @@ under the License.
   <description>Wagon provider that gets and puts artifacts using SSH protocol with a preinstalled SSH client</description>
 
   <properties>
+    <wagon.automatic.module.name>org.apache.maven.wagon.providers.ssh.external</wagon.automatic.module.name>
     <sshd.stopImmediatly>false</sshd.stopImmediatly>
   </properties>
 

--- a/wagon-providers/wagon-ssh/pom.xml
+++ b/wagon-providers/wagon-ssh/pom.xml
@@ -30,6 +30,7 @@ under the License.
   <name>Apache Maven Wagon :: Providers :: SSH Provider</name>
 
   <properties>
+    <wagon.automatic.module.name>org.apache.maven.wagon.providers.ssh</wagon.automatic.module.name>
     <sshd.stopImmediatly>false</sshd.stopImmediatly>
   </properties>
 

--- a/wagon-providers/wagon-webdav-jackrabbit/pom.xml
+++ b/wagon-providers/wagon-webdav-jackrabbit/pom.xml
@@ -41,6 +41,10 @@ under the License.
     </contributor>
   </contributors>
 
+  <properties>
+    <wagon.automatic.module.name>org.apache.maven.wagon.providers.webdav</wagon.automatic.module.name>
+  </properties>
+
   <dependencies>
     <dependency>
       <!-- Workaround for QDOX-148, see also MNG-3686 -->

--- a/wagon-tcks/wagon-tck-http/pom.xml
+++ b/wagon-tcks/wagon-tck-http/pom.xml
@@ -31,6 +31,10 @@ under the License.
 
   <name>Apache Maven Wagon :: HTTP Test Compatibility Kit</name>
 
+  <properties>
+    <wagon.automatic.module.name>org.apache.maven.wagon.tck.http</wagon.automatic.module.name>
+  </properties>
+
   <dependencies>
     <dependency>
       <groupId>org.eclipse.sisu</groupId>


### PR DESCRIPTION
Introduce `Automatic-Module-Name` manifest entries across all published Wagon JAR artifacts to support Java 9+ JPMS consumers.

Module names:
- `wagon-provider-api`: `org.apache.maven.wagon.provider.api`
- `wagon-provider-test`: `org.apache.maven.wagon.provider.test`
- `wagon-file`: `org.apache.maven.wagon.providers.file`
- `wagon-ftp`: `org.apache.maven.wagon.providers.ftp`
- `wagon-http`: `org.apache.maven.wagon.providers.http`
- `wagon-http-lightweight`: `org.apache.maven.wagon.providers.http.lightweight`
- `wagon-http-shared`: `org.apache.maven.wagon.providers.http.shared`
- `wagon-scm`: `org.apache.maven.wagon.providers.scm`
- `wagon-ssh`: `org.apache.maven.wagon.providers.ssh`
- `wagon-ssh-common`: `org.apache.maven.wagon.providers.ssh.common`
- `wagon-ssh-common-test`: `org.apache.maven.wagon.providers.ssh.common.test`
- `wagon-ssh-external`: `org.apache.maven.wagon.providers.ssh.external`
- `wagon-webdav-jackrabbit`: `org.apache.maven.wagon.providers.webdav`
- `wagon-tck-http`: `org.apache.maven.wagon.tck.http`

Fixes #853