### PR TITLE
Upgrade Jetty to 9.4.58.v20250814 and de-aggregate jetty-all (#943)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -242,9 +242,11 @@ under the License.
       </dependency>
 
       <dependency>
-        <groupId>org.eclipse.jetty.aggregate</groupId>
-        <artifactId>jetty-all</artifactId>
-        <version>9.2.30.v20200428</version>
+        <groupId>org.eclipse.jetty</groupId>
+        <artifactId>jetty-bom</artifactId>
+        <version>9.4.58.v20250814</version>
+        <type>pom</type>
+        <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>javax.servlet</groupId>

--- a/wagon-provider-test/pom.xml
+++ b/wagon-provider-test/pom.xml
@@ -66,8 +66,24 @@ under the License.
       <scope>compile</scope>
     </dependency>
     <dependency>
-      <groupId>org.eclipse.jetty.aggregate</groupId>
-      <artifactId>jetty-all</artifactId>
+      <groupId>org.eclipse.jetty</groupId>
+      <artifactId>jetty-server</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.jetty</groupId>
+      <artifactId>jetty-servlet</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.jetty</groupId>
+      <artifactId>jetty-security</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.jetty</groupId>
+      <artifactId>jetty-util</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.jetty</groupId>
+      <artifactId>jetty-http</artifactId>
     </dependency>
     <dependency>
       <groupId>javax.servlet</groupId>

--- a/wagon-provider-test/src/main/java/org/apache/maven/wagon/http/HttpWagonTestCase.java
+++ b/wagon-provider-test/src/main/java/org/apache/maven/wagon/http/HttpWagonTestCase.java
@@ -65,6 +65,7 @@ import org.eclipse.jetty.security.ConstraintMapping;
 import org.eclipse.jetty.security.ConstraintSecurityHandler;
 import org.eclipse.jetty.security.HashLoginService;
 import org.eclipse.jetty.security.SecurityHandler;
+import org.eclipse.jetty.security.UserStore;
 import org.eclipse.jetty.security.authentication.BasicAuthenticator;
 import org.eclipse.jetty.server.Connector;
 import org.eclipse.jetty.server.HttpConfiguration;
@@ -427,6 +428,7 @@ public abstract class HttpWagonTestCase extends StreamingWagonTestCase {
         root.setResourceBase(localRepositoryPath);
         ServletHolder servletHolder = new ServletHolder(new DefaultServlet());
         servletHolder.setInitParameter("gzip", "true");
+        servletHolder.setInitParameter("precompressed", "true");
         root.addServlet(servletHolder, "/*");
         addConnector(server);
         server.setHandler(root);
@@ -1475,6 +1477,11 @@ public abstract class HttpWagonTestCase extends StreamingWagonTestCase {
         OutputStream out = new FileOutputStream(file);
         try {
             out.write(child.getBytes());
+            // Pad uncompressed file so compressed.length() < uncompressed.length()
+            // (Jetty 9.4 ResourceService only serves precompressed files if compressed size is smaller)
+            for (int i = 0; i < 100; i++) {
+                out.write(child.getBytes());
+            }
         } finally {
             out.close();
         }
@@ -1982,7 +1989,9 @@ public abstract class HttpWagonTestCase extends StreamingWagonTestCase {
 
         TestSecurityHandler sh = new TestSecurityHandler();
         HashLoginService hashLoginService = new HashLoginService("MyRealm");
-        hashLoginService.putUser("user", new Password("secret"), new String[] {"admin"});
+        UserStore userStore = new UserStore();
+        userStore.addUser("user", new Password("secret"), new String[] {"admin"});
+        hashLoginService.setUserStore(userStore);
         sh.setLoginService(hashLoginService);
         sh.setConstraintMappings(new ConstraintMapping[] {cm});
         sh.setAuthenticator(new BasicAuthenticator());

--- a/wagon-providers/wagon-http-lightweight/pom.xml
+++ b/wagon-providers/wagon-http-lightweight/pom.xml
@@ -59,8 +59,13 @@ under the License.
       <artifactId>slf4j-api</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.eclipse.jetty.aggregate</groupId>
-      <artifactId>jetty-all</artifactId>
+      <groupId>org.eclipse.jetty</groupId>
+      <artifactId>jetty-server</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.jetty</groupId>
+      <artifactId>jetty-util</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/wagon-providers/wagon-http/pom.xml
+++ b/wagon-providers/wagon-http/pom.xml
@@ -81,8 +81,18 @@ under the License.
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.eclipse.jetty.aggregate</groupId>
-      <artifactId>jetty-all</artifactId>
+      <groupId>org.eclipse.jetty</groupId>
+      <artifactId>jetty-server</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.jetty</groupId>
+      <artifactId>jetty-servlet</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.jetty</groupId>
+      <artifactId>jetty-util</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/wagon-providers/wagon-http/src/test/java/org/apache/maven/wagon/providers/http/ErrorWithMessageServlet.java
+++ b/wagon-providers/wagon-http/src/test/java/org/apache/maven/wagon/providers/http/ErrorWithMessageServlet.java
@@ -55,16 +55,24 @@ public class ErrorWithMessageServlet extends HttpServlet {
     public static final String MESSAGE = "it sucks!";
 
     public void service(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
+        int status = 0;
         if (request.getPathInfo().endsWith("/401")) {
-            response.sendError(401, MESSAGE);
+            status = 401;
         } else if (request.getPathInfo().endsWith("/403")) {
-            response.sendError(403, MESSAGE);
+            status = 403;
         } else if (request.getPathInfo().endsWith("/404")) {
-            response.sendError(404, MESSAGE);
+            status = 404;
         } else if (request.getPathInfo().endsWith("/407")) {
-            response.sendError(407, MESSAGE);
+            status = 407;
         } else if (request.getPathInfo().endsWith("/500")) {
-            response.sendError(500, MESSAGE);
+            status = 500;
+        }
+        if (status > 0) {
+            if (response instanceof org.eclipse.jetty.server.Response) {
+                ((org.eclipse.jetty.server.Response) response).setStatusWithReason(status, MESSAGE);
+            } else {
+                response.sendError(status, MESSAGE);
+            }
         }
     }
 }

--- a/wagon-providers/wagon-http/src/test/java/org/apache/maven/wagon/providers/http/HttpWagonHttpServerTestCase.java
+++ b/wagon-providers/wagon-http/src/test/java/org/apache/maven/wagon/providers/http/HttpWagonHttpServerTestCase.java
@@ -46,8 +46,6 @@ public abstract class HttpWagonHttpServerTestCase {
         server = new Server(0);
 
         context = new ServletContextHandler(ServletContextHandler.SESSIONS);
-        resourceHandler = new ResourceHandler();
-        context.setHandler(resourceHandler);
         server.setHandler(context);
     }
 

--- a/wagon-providers/wagon-ssh/pom.xml
+++ b/wagon-providers/wagon-ssh/pom.xml
@@ -58,8 +58,8 @@ under the License.
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.eclipse.jetty.aggregate</groupId>
-      <artifactId>jetty-all</artifactId>
+      <groupId>org.eclipse.jetty</groupId>
+      <artifactId>jetty-server</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/wagon-providers/wagon-webdav-jackrabbit/pom.xml
+++ b/wagon-providers/wagon-webdav-jackrabbit/pom.xml
@@ -84,8 +84,18 @@ under the License.
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.eclipse.jetty.aggregate</groupId>
-      <artifactId>jetty-all</artifactId>
+      <groupId>org.eclipse.jetty</groupId>
+      <artifactId>jetty-server</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.jetty</groupId>
+      <artifactId>jetty-servlet</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.jetty</groupId>
+      <artifactId>jetty-util</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/wagon-tcks/wagon-tck-http/pom.xml
+++ b/wagon-tcks/wagon-tck-http/pom.xml
@@ -53,8 +53,24 @@ under the License.
       <version>2.12.1</version>
     </dependency>
     <dependency>
-      <groupId>org.eclipse.jetty.aggregate</groupId>
-      <artifactId>jetty-all</artifactId>
+      <groupId>org.eclipse.jetty</groupId>
+      <artifactId>jetty-server</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.jetty</groupId>
+      <artifactId>jetty-servlet</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.jetty</groupId>
+      <artifactId>jetty-security</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.jetty</groupId>
+      <artifactId>jetty-util</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.jetty</groupId>
+      <artifactId>jetty-webapp</artifactId>
     </dependency>
     <dependency>
       <groupId>javax.servlet</groupId>

--- a/wagon-tcks/wagon-tck-http/src/main/java/org/apache/maven/wagon/tck/http/fixture/ServerFixture.java
+++ b/wagon-tcks/wagon-tck-http/src/main/java/org/apache/maven/wagon/tck/http/fixture/ServerFixture.java
@@ -28,12 +28,13 @@ import java.net.URISyntaxException;
 import org.eclipse.jetty.security.ConstraintMapping;
 import org.eclipse.jetty.security.ConstraintSecurityHandler;
 import org.eclipse.jetty.security.HashLoginService;
+import org.eclipse.jetty.security.UserStore;
+import org.eclipse.jetty.security.authentication.BasicAuthenticator;
 import org.eclipse.jetty.server.Handler;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.ServerConnector;
 import org.eclipse.jetty.server.handler.DefaultHandler;
 import org.eclipse.jetty.server.handler.HandlerCollection;
-import org.eclipse.jetty.server.session.AbstractSessionManager;
 import org.eclipse.jetty.server.session.SessionHandler;
 import org.eclipse.jetty.servlet.FilterHolder;
 import org.eclipse.jetty.servlet.FilterMapping;
@@ -69,6 +70,7 @@ public class ServerFixture {
     private final WebAppContext webappContext;
 
     private final HashLoginService loginService;
+    private final UserStore userStore;
 
     private final ConstraintSecurityHandler securityHandler;
 
@@ -111,9 +113,12 @@ public class ServerFixture {
         securityHandler = new ConstraintSecurityHandler();
 
         loginService = new HashLoginService("Test Server");
+        userStore = new UserStore();
+        loginService.setUserStore(userStore);
 
         securityHandler.setLoginService(loginService);
         securityHandler.setConstraintMappings(new ConstraintMapping[] {cm});
+        securityHandler.setAuthenticator(new BasicAuthenticator());
 
         webappContext = new WebAppContext();
         webappContext.setContextPath("/");
@@ -124,7 +129,7 @@ public class ServerFixture {
         webappContext.setHandler(securityHandler);
 
         SessionHandler sessionHandler = webappContext.getSessionHandler();
-        ((AbstractSessionManager) sessionHandler.getSessionManager()).setUsingCookies(false);
+        sessionHandler.setUsingCookies(false);
 
         HandlerCollection handlers = new HandlerCollection();
         handlers.setHandlers(new Handler[] {webappContext, new DefaultHandler()});
@@ -150,7 +155,7 @@ public class ServerFixture {
     }
 
     public void addUser(final String user, final String password) {
-        loginService.putUser(user, new Password(password), new String[] {"allowed"});
+        userStore.addUser(user, new Password(password), new String[] {"allowed"});
     }
 
     public Server getServer() {


### PR DESCRIPTION
Backport of Jetty 9.4 upgrade and de-aggregation to `wagon-3.x`.

Fixes #943.

- Replaced `jetty-all:9.2.30.v20200428` with `org.eclipse.jetty:jetty-bom:9.4.58.v20250814` in root dependency management.
- De-aggregated into modular artifacts (`jetty-server`, `jetty-servlet`, `jetty-security`, `jetty-util`, `jetty-http`, `jetty-webapp`) with appropriate scopes.
- Adapted Jetty 9.4 APIs:
  - Configured `UserStore` for `HashLoginService` in `HttpWagonTestCase` and `ServerFixture`.
  - Configured `BasicAuthenticator` explicitly on `ConstraintSecurityHandler` in `ServerFixture`.
  - Replaced `AbstractSessionManager` cookies setup with `sessionHandler.setUsingCookies(false)`.
  - Handled Jetty 9.4 `ResourceService` precompressed file requirements in `HttpWagonTestCase` (setting `precompressed` init parameter and ensuring uncompressed test file is larger than compressed counterpart).
  - Used `setStatusWithReason` for HTTP error message testing in `ErrorWithMessageServlet`.