### PR TITLE
Stop wagon-http from publishing a dependency-reduced POM

### DIFF
--- a/wagon-providers/wagon-http/pom.xml
+++ b/wagon-providers/wagon-http/pom.xml
@@ -169,7 +169,7 @@ under the License.
                   <shadedPattern>org.apache.maven.wagon.providers.http.wagon.shared</shadedPattern>
                 </relocation>
               </relocations>
-              <dependencyReducedPomLocation>${project.build.directory}/dependency-reduced-pom.xml</dependencyReducedPomLocation>
+              <createDependencyReducedPom>false</createDependencyReducedPom>
             </configuration>
           </execution>
         </executions>


### PR DESCRIPTION
`wagon-http`'s main jar is unshaded and needs `wagon-http-shared` and `httpclient` at runtime, but the shade execution was reducing them out of the installed POM, leaving `HttpWagon` unable to load `AbstractHttpClientWagon`. Fixes #972.

Verified: `mvn install` on the module → installed POM declares `wagon-http-shared`, `httpclient` and `httpcore` again; both the plain and `-shaded` jars still produced; no `dependency-reduced-pom.xml` in the basedir, so #750 stays fixed. A rebuilt Maven 3.9.17-SNAPSHOT distribution ships `wagon-http-shared` again, and `-Dmaven.resolver.transport=wagon` selects `WagonTransporter` for both a `file://` repository and central, matching released 3.9.16.

`master` needs the same change.

*This change was created with AI assistance.*
