### PR TITLE
Stop wagon-http from publishing a dependency-reduced POM

### DIFF
--- a/wagon-providers/wagon-http/pom.xml
+++ b/wagon-providers/wagon-http/pom.xml
@@ -169,7 +169,7 @@ under the License.
                   <shadedPattern>org.apache.maven.wagon.providers.http.wagon.shared</shadedPattern>
                 </relocation>
               </relocations>
-              <dependencyReducedPomLocation>${project.build.directory}/dependency-reduced-pom.xml</dependencyReducedPomLocation>
+              <createDependencyReducedPom>false</createDependencyReducedPom>
             </configuration>
           </execution>
         </executions>


### PR DESCRIPTION
Master carries the same shade configuration as `wagon-3.x`, so it produces the same broken `wagon-http` POM. This is the master counterpart of #973. See #972 for the full analysis.

Verified on this branch: `mvn install` on the module → the installed 4.0.0-M1-SNAPSHOT POM declares `wagon-http-shared`, `httpclient` and `httpcore` again; both the plain and `-shaded` jars are still produced; no `dependency-reduced-pom.xml` in the basedir, so #750 stays fixed. `spotless:check` passes.

*This change was created with AI assistance.*
