### PR TITLE
Replace the deprecated plexus-utils APIs in provider code

### DIFF
--- a/wagon-providers/wagon-http-lightweight/src/main/java/org/apache/maven/wagon/providers/http/LightweightHttpWagon.java
+++ b/wagon-providers/wagon-http-lightweight/src/main/java/org/apache/maven/wagon/providers/http/LightweightHttpWagon.java
@@ -34,6 +34,7 @@ import java.net.Proxy.Type;
 import java.net.SocketAddress;
 import java.net.URL;
 import java.util.ArrayList;
+import java.util.Base64;
 import java.util.List;
 import java.util.Properties;
 import java.util.regex.Matcher;
@@ -53,7 +54,6 @@ import org.apache.maven.wagon.events.TransferEvent;
 import org.apache.maven.wagon.proxy.ProxyInfo;
 import org.apache.maven.wagon.resource.Resource;
 import org.apache.maven.wagon.shared.http.EncodingUtil;
-import org.codehaus.plexus.util.Base64;
 
 import static java.lang.Integer.parseInt;
 import static org.apache.maven.wagon.shared.http.HttpMessageUtils.UNKNOWN_STATUS_CODE;
@@ -201,7 +201,7 @@ public class LightweightHttpWagon extends StreamWagon {
     private void setAuthorization(HttpURLConnection urlConnection) {
         if (preemptiveAuthentication && authenticationInfo != null && authenticationInfo.getUserName() != null) {
             String credentials = authenticationInfo.getUserName() + ":" + authenticationInfo.getPassword();
-            String encoded = new String(Base64.encodeBase64(credentials.getBytes()));
+            String encoded = Base64.getEncoder().encodeToString(credentials.getBytes());
             urlConnection.setRequestProperty("Authorization", "Basic " + encoded);
         }
     }

--- a/wagon-providers/wagon-ssh-common/src/main/java/org/apache/maven/wagon/providers/ssh/knownhost/StreamKnownHostsProvider.java
+++ b/wagon-providers/wagon-ssh-common/src/main/java/org/apache/maven/wagon/providers/ssh/knownhost/StreamKnownHostsProvider.java
@@ -19,14 +19,13 @@
 package org.apache.maven.wagon.providers.ssh.knownhost;
 
 import java.io.BufferedReader;
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.StringReader;
 import java.util.HashSet;
 import java.util.Set;
 
-import org.codehaus.plexus.util.IOUtil;
-import org.codehaus.plexus.util.StringOutputStream;
 import org.codehaus.plexus.util.StringUtils;
 
 /**
@@ -38,18 +37,17 @@ import org.codehaus.plexus.util.StringUtils;
 public class StreamKnownHostsProvider extends AbstractKnownHostsProvider {
 
     public StreamKnownHostsProvider(InputStream stream) throws IOException {
-        try {
-            StringOutputStream stringOutputStream = new StringOutputStream();
-            IOUtil.copy(stream, stringOutputStream);
+        try (InputStream in = stream) {
+            ByteArrayOutputStream buffer = new ByteArrayOutputStream();
+            byte[] chunk = new byte[4096];
+            int read;
+            while ((read = in.read(chunk)) != -1) {
+                buffer.write(chunk, 0, read);
+            }
 
-            stream.close();
-            stream = null;
-
-            this.contents = stringOutputStream.toString();
+            this.contents = buffer.toString();
 
             this.knownHosts = this.loadKnownHosts(this.contents);
-        } finally {
-            IOUtil.close(stream);
         }
     }
 

--- a/wagon-providers/wagon-ssh/src/main/java/org/apache/maven/wagon/providers/ssh/jsch/AbstractJschWagon.java
+++ b/wagon-providers/wagon-ssh/src/main/java/org/apache/maven/wagon/providers/ssh/jsch/AbstractJschWagon.java
@@ -23,6 +23,7 @@ import javax.inject.Named;
 
 import java.io.BufferedReader;
 import java.io.ByteArrayInputStream;
+import java.io.Closeable;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
@@ -73,7 +74,6 @@ import org.apache.maven.wagon.providers.ssh.knownhost.KnownHostsProvider;
 import org.apache.maven.wagon.providers.ssh.knownhost.UnknownHostException;
 import org.apache.maven.wagon.proxy.ProxyInfo;
 import org.apache.maven.wagon.resource.Resource;
-import org.codehaus.plexus.util.IOUtil;
 
 /**
  * AbstractJschWagon
@@ -371,10 +371,20 @@ public abstract class AbstractJschWagon extends StreamWagon implements SshWagon,
                 fireSessionDebug("Stderr results:" + streams.getErr());
             }
 
-            IOUtil.close(stdoutReader);
-            IOUtil.close(stderrReader);
+            closeQuietly(stdoutReader);
+            closeQuietly(stderrReader);
             if (channel != null) {
                 channel.disconnect();
+            }
+        }
+    }
+
+    private static void closeQuietly(Closeable closeable) {
+        if (closeable != null) {
+            try {
+                closeable.close();
+            } catch (IOException e) {
+                // ignored, as IOUtil.close did before
             }
         }
     }


### PR DESCRIPTION
Master counterpart of #976, cherry-picked clean. See #975 for the survey.

Verified on this branch: `mvn install` on the three modules and their prerequisites → BUILD SUCCESS, `wagon-http-lightweight` 219/0/0 (7 skipped), `wagon-ssh-common` 10/0/0, `wagon-ssh-common-test` 19/0/0. `spotless:check` passes.

*This change was created with AI assistance.*
