### PR TITLE
Negotiate the FTPS data channel protection level

### DIFF
--- a/wagon-providers/wagon-ftp/src/main/java/org/apache/maven/wagon/providers/ftp/FtpWagon.java
+++ b/wagon-providers/wagon-ftp/src/main/java/org/apache/maven/wagon/providers/ftp/FtpWagon.java
@@ -141,6 +141,8 @@ public class FtpWagon extends StreamWagon {
                 throw new AuthenticationException("Cannot login to remote system");
             }
 
+            afterLogin(ftp);
+
             fireSessionDebug("Remote system is " + ftp.getSystemName());
 
             // Set to binary mode.
@@ -159,6 +161,17 @@ public class FtpWagon extends StreamWagon {
 
     protected FTPClient createClient() {
         return new FTPClient();
+    }
+
+    /**
+     * Negotiates anything that can only be negotiated once the session is authenticated. Called after a successful
+     * login and before the session is configured for transfer. Does nothing for plain FTP.
+     *
+     * @param client the connected and authenticated client
+     * @throws IOException if the negotiation fails
+     */
+    protected void afterLogin(FTPClient client) throws IOException {
+        // nothing to do
     }
 
     @Override

--- a/wagon-providers/wagon-ftp/src/main/java/org/apache/maven/wagon/providers/ftp/FtpsWagon.java
+++ b/wagon-providers/wagon-ftp/src/main/java/org/apache/maven/wagon/providers/ftp/FtpsWagon.java
@@ -20,6 +20,8 @@ package org.apache.maven.wagon.providers.ftp;
 
 import javax.inject.Named;
 
+import java.io.IOException;
+
 import org.apache.commons.net.ftp.FTPClient;
 import org.apache.commons.net.ftp.FTPSClient;
 import org.slf4j.Logger;
@@ -40,6 +42,12 @@ public class FtpsWagon extends FtpWagon {
 
     private boolean endpointChecking = true;
 
+    /**
+     * RFC 4217 data channel protection level: {@code P} for a protected data connection, {@code C} for a clear one.
+     * Empty or {@code null} sends no {@code PROT} command at all, which leaves the server on its own default.
+     */
+    private String dataChannelProtection = "P";
+
     @Override
     protected FTPClient createClient() {
         LOG.debug(
@@ -50,5 +58,30 @@ public class FtpsWagon extends FtpWagon {
         FTPSClient client = new FTPSClient(securityProtocol, implicit);
         client.setEndpointCheckingEnabled(endpointChecking);
         return client;
+    }
+
+    public String getDataChannelProtection() {
+        return dataChannelProtection;
+    }
+
+    public void setDataChannelProtection(String dataChannelProtection) {
+        this.dataChannelProtection = dataChannelProtection;
+    }
+
+    /**
+     * Negotiates the data channel protection level. Without this the data connection stays clear even though the
+     * control connection is encrypted, and a server that requires protection answers a transfer with
+     * {@code 425 Server requires protected data connection}.
+     */
+    @Override
+    protected void afterLogin(FTPClient client) throws IOException {
+        if (dataChannelProtection == null || dataChannelProtection.isEmpty()) {
+            return;
+        }
+        LOG.debug("Setting FTPS data channel protection level to [{}].", dataChannelProtection);
+        FTPSClient secureClient = (FTPSClient) client;
+        // PBSZ 0 is what RFC 4217 requires before PROT over TLS
+        secureClient.execPBSZ(0);
+        secureClient.execPROT(dataChannelProtection);
     }
 }

--- a/wagon-providers/wagon-ftp/src/test/java/org/apache/maven/wagon/providers/ftp/FtpWagonTest.java
+++ b/wagon-providers/wagon-ftp/src/test/java/org/apache/maven/wagon/providers/ftp/FtpWagonTest.java
@@ -21,8 +21,10 @@ package org.apache.maven.wagon.providers.ftp;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.apache.commons.io.FileUtils;
+import org.apache.commons.net.ftp.FTPClient;
 import org.apache.ftpserver.FtpServer;
 import org.apache.ftpserver.FtpServerFactory;
 import org.apache.ftpserver.ftplet.Authority;
@@ -43,6 +45,7 @@ import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
 /**
@@ -141,6 +144,29 @@ public class FtpWagonTest extends StreamingWagonTestCase {
 
     private File getRepositoryDirectory() {
         return getTestFile("target/test-output/local-repository");
+    }
+
+    @Test
+    public void testAfterLoginIsCalledOnConnect() throws Exception {
+        AtomicBoolean called = new AtomicBoolean();
+        FtpWagon wagon = new FtpWagon() {
+            @Override
+            protected void afterLogin(FTPClient client) {
+                called.set(true);
+            }
+        };
+
+        setupWagonTestingFixtures();
+        try {
+            wagon.connect(new Repository("id", getTestRepositoryUrl()), getAuthInfo());
+            try {
+                assertTrue(called.get(), "afterLogin was not called after a successful login");
+            } finally {
+                wagon.disconnect();
+            }
+        } finally {
+            tearDownWagonTestingFixtures();
+        }
     }
 
     @Test

--- a/wagon-providers/wagon-ftp/src/test/java/org/apache/maven/wagon/providers/ftp/FtpsWagonTest.java
+++ b/wagon-providers/wagon-ftp/src/test/java/org/apache/maven/wagon/providers/ftp/FtpsWagonTest.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.wagon.providers.ftp;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import org.apache.commons.net.ftp.FTPSClient;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Covers the data channel protection negotiated after login, without opening a connection: the recording client
+ * intercepts the two commands rather than sending them.
+ */
+class FtpsWagonTest {
+
+    @Test
+    void protectsTheDataChannelByDefault() throws IOException {
+        RecordingFtpsClient client = new RecordingFtpsClient();
+
+        new FtpsWagon().afterLogin(client);
+
+        // PBSZ 0 has to precede PROT over TLS, per RFC 4217
+        assertEquals(Arrays.asList("PBSZ 0", "PROT P"), client.commands);
+    }
+
+    @Test
+    void honoursAConfiguredProtectionLevel() throws IOException {
+        RecordingFtpsClient client = new RecordingFtpsClient();
+        FtpsWagon wagon = new FtpsWagon();
+        wagon.setDataChannelProtection("C");
+
+        wagon.afterLogin(client);
+
+        assertEquals(Arrays.asList("PBSZ 0", "PROT C"), client.commands);
+    }
+
+    @Test
+    void sendsNothingWhenProtectionIsUnset() throws IOException {
+        RecordingFtpsClient client = new RecordingFtpsClient();
+        FtpsWagon wagon = new FtpsWagon();
+        wagon.setDataChannelProtection(null);
+
+        wagon.afterLogin(client);
+
+        assertEquals(Collections.emptyList(), client.commands);
+    }
+
+    private static final class RecordingFtpsClient extends FTPSClient {
+
+        private final List<String> commands = new ArrayList<>();
+
+        @Override
+        public void execPBSZ(long pbsz) {
+            commands.add("PBSZ " + pbsz);
+        }
+
+        @Override
+        public void execPROT(String prot) {
+            commands.add("PROT " + prot);
+        }
+    }
+}


### PR DESCRIPTION
Master counterpart of #978, cherry-picked clean. See #651 for the report and #978 for the reasoning behind the default.

Verified on this branch: `mvn test -pl wagon-providers/wagon-ftp -am` → 27 tests, 0 failures. `spotless:check` passes.

*This change was created with AI assistance.*
