### PR TITLE
Remove wagon-1.x from protected_branches in .asf.yaml

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -27,7 +27,6 @@ github:
   protected_branches:
     master: { }
     wagon-3.x: { }
-    wagon-1.x: { }
   pull_requests:
     del_branch_on_merge: true
   enabled_merge_buttons:


### PR DESCRIPTION
Retire and unprotect legacy `wagon-1.x` branch, which has been tagged as `archive/wagon-1.x`.