### PR TITLE
Give MKCOL the status vocabulary RFC 4918 defines

### DIFF
--- a/wagon-providers/wagon-webdav-jackrabbit/src/main/java/org/apache/maven/wagon/providers/webdav/WebDavWagon.java
+++ b/wagon-providers/wagon-webdav-jackrabbit/src/main/java/org/apache/maven/wagon/providers/webdav/WebDavWagon.java
@@ -105,30 +105,57 @@ public class WebDavWagon extends AbstractHttpClientWagon {
         // create relative path that will always have a leading and trailing slash
         String relpath = FileUtils.normalize(getPath(basedir, dir) + "/");
 
+        mkColPath(baseUrl, relpath);
+    }
+
+    /**
+     * Creates every missing collection along {@code relpath}, one at a time.
+     * <p>
+     * RFC 4918 section 9.3.1 gives MKCOL a small vocabulary, and only two of the answers mean "keep going".
+     * {@code 201 Created} is a collection we made, {@code 405 Method Not Allowed} one that was already there, and
+     * {@code 409 Conflict} says an ancestor is missing -- which is the only reason to step further back. Anything
+     * else, a {@code 403} or an authentication failure for instance, is reported where it happens rather than
+     * being mistaken for a missing parent.
+     *
+     * @param baseUrl scheme, host and port of the repository, without a trailing slash
+     * @param relpath repository-relative path with a leading and trailing slash
+     */
+    void mkColPath(String baseUrl, String relpath) throws IOException {
         PathNavigator navigator = new PathNavigator(relpath);
 
-        // traverse backwards until we hit a directory that already exists (OK/NOT_ALLOWED), or that we were able to
-        // create (CREATED), or until we get to the top of the path
-        int status = -1;
+        // step backwards while the server reports a missing ancestor, until one exists or we create one
+        int status;
         do {
             String url = baseUrl + "/" + navigator.getPath();
             status = doMkCol(url);
             if (status == HttpStatus.SC_CREATED || status == HttpStatus.SC_METHOD_NOT_ALLOWED) {
                 break;
             }
+            if (status != HttpStatus.SC_CONFLICT) {
+                throw new IOException(unableToCreate(url, status));
+            }
         } while (navigator.backward());
+
+        if (status != HttpStatus.SC_CREATED && status != HttpStatus.SC_METHOD_NOT_ALLOWED) {
+            throw new IOException(unableToCreate(baseUrl + "/" + navigator.getPath(), status));
+        }
 
         // traverse forward creating missing directories
         while (navigator.forward()) {
             String url = baseUrl + "/" + navigator.getPath();
             status = doMkCol(url);
-            if (status != HttpStatus.SC_CREATED) {
-                throw new IOException("Unable to create collection: " + url + "; status code = " + status);
+            // a collection that already exists is as good as one we just created
+            if (status != HttpStatus.SC_CREATED && status != HttpStatus.SC_METHOD_NOT_ALLOWED) {
+                throw new IOException(unableToCreate(url, status));
             }
         }
     }
 
-    private int doMkCol(String url) throws IOException {
+    private static String unableToCreate(String url, int status) {
+        return "Unable to create collection: " + url + "; status code = " + status;
+    }
+
+    int doMkCol(String url) throws IOException {
         DavMethods.HttpMkcol method = new DavMethods.HttpMkcol(url);
         try (CloseableHttpResponse closeableHttpResponse = execute(method)) {
             return closeableHttpResponse.getStatusLine().getStatusCode();

--- a/wagon-providers/wagon-webdav-jackrabbit/src/test/java/org/apache/maven/wagon/providers/webdav/WebDavWagonMkColTest.java
+++ b/wagon-providers/wagon-webdav-jackrabbit/src/test/java/org/apache/maven/wagon/providers/webdav/WebDavWagonMkColTest.java
@@ -1,0 +1,126 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.wagon.providers.webdav;
+
+import java.io.IOException;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Deque;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Drives the MKCOL status handling of {@link WebDavWagon#mkColPath} with scripted responses, which the
+ * server-backed tests in {@link WebDavWagonTest} cannot do: a real server never answers 403 on demand, and never
+ * loses a race that turns a forward MKCOL into a 405.
+ */
+class WebDavWagonMkColTest {
+
+    private static final String BASE = "http://host";
+
+    @Test
+    void createsEveryMissingCollectionFromTheTopDown() throws IOException {
+        // nothing exists, so the walk back reports a missing ancestor until the root, then creates on the way down
+        ScriptedWagon wagon = new ScriptedWagon(409, 409, 409, 201, 201, 201, 201);
+
+        wagon.mkColPath(BASE, "/a/b/c/");
+
+        assertEquals(
+                Arrays.asList(
+                        BASE + "/a/b/c/",
+                        BASE + "/a/b/",
+                        BASE + "/a/",
+                        BASE + "/",
+                        BASE + "/a/",
+                        BASE + "/a/b/",
+                        BASE + "/a/b/c/"),
+                wagon.requested);
+    }
+
+    @Test
+    void stopsWalkingBackAtACollectionThatAlreadyExists() throws IOException {
+        // 405 means "already a collection here", so the walk back stops and only the rest is created
+        ScriptedWagon wagon = new ScriptedWagon(409, 409, 405, 201, 201);
+
+        wagon.mkColPath(BASE, "/a/b/c/");
+
+        assertEquals(5, wagon.requested.size());
+        assertEquals(BASE + "/a/", wagon.requested.get(2));
+    }
+
+    @Test
+    void toleratesACollectionAppearingUnderneathUsOnTheWayDown() throws IOException {
+        // someone else created a/b between our walk back and our walk down; 405 there is not a failure
+        ScriptedWagon wagon = new ScriptedWagon(409, 409, 405, 405, 201);
+
+        wagon.mkColPath(BASE, "/a/b/c/");
+
+        assertEquals(5, wagon.requested.size());
+    }
+
+    @Test
+    void reportsARefusalWhereItHappensRatherThanWalkingPastIt() {
+        // 403 is not "the parent is missing", so it must stop at once instead of walking to the root
+        ScriptedWagon wagon = new ScriptedWagon(403);
+
+        IOException e = assertThrows(IOException.class, () -> wagon.mkColPath(BASE, "/a/b/c/"));
+
+        assertEquals(1, wagon.requested.size(), "walked past a refusal instead of reporting it");
+        assertTrue(e.getMessage().contains(BASE + "/a/b/c/"), e.getMessage());
+        assertTrue(e.getMessage().contains("403"), e.getMessage());
+    }
+
+    @Test
+    void failsWhenTheWholePathIsExhaustedAndStillConflicting() {
+        // the server claims a missing ancestor all the way to the root; there is nowhere left to go
+        ScriptedWagon wagon = new ScriptedWagon(409, 409, 409, 409);
+
+        IOException e = assertThrows(IOException.class, () -> wagon.mkColPath(BASE, "/a/b/c/"));
+
+        assertEquals(4, wagon.requested.size());
+        assertTrue(e.getMessage().contains("409"), e.getMessage());
+    }
+
+    private static final class ScriptedWagon extends WebDavWagon {
+
+        private final Deque<Integer> statuses = new ArrayDeque<>();
+        private final List<String> requested = new ArrayList<>();
+
+        ScriptedWagon(int... statuses) {
+            for (int status : statuses) {
+                this.statuses.add(status);
+            }
+        }
+
+        @Override
+        int doMkCol(String url) {
+            requested.add(url);
+            if (statuses.isEmpty()) {
+                throw new IllegalStateException("unexpected MKCOL of " + url + "; the script ran out");
+            }
+            return statuses.removeFirst();
+        }
+    }
+}


### PR DESCRIPTION
`WebDavWagon.mkdirs` recognised only `201` and `405`, and read everything else as "the ancestor is missing". Two consequences, both from the third bullet of #630:

- A `403`, or an authentication failure, sent the walk further back instead of being reported. It kept stepping up to the root and then failed on the way down, naming a path that was never the problem.
- On the way down only `201` was accepted, so a collection that appeared underneath us — a concurrent deploy, or an intermediate that already existed — failed the upload with `405`.

RFC 4918 section 9.3.1 gives MKCOL a small vocabulary: `201` is a collection we created, `405` one that was already there, and `409` says an ancestor is missing. Only `409` is a reason to step back; only the first two mean carry on. Anything else is now reported where it happens.

The traversal moved into a package-private `mkColPath(baseUrl, relpath)` so the status handling can be driven without a server, and `doMkCol` went from private to package-private as the seam. No public API changes.

Verified: `mvn install -pl wagon-providers/wagon-webdav-jackrabbit -am` → 308 tests, 0 failures, including all four 71-test server-backed suites unchanged. The new `WebDavWagonMkColTest` scripts the statuses a real server will not produce on demand. Negative control: reverting the production change turns 3 of its 5 cases red — one per defect above, plus the exhausted-path case — while the two describing preserved behaviour stay green. `spotless:check` passes.

This does not close #630 on its own: the remaining bullet there is that the WebDAV tests still run through the HTTP test base.

*This change was created with AI assistance.*
