### PR TITLE
Keep the JSR-330 annotations off the wagon transitive classpath

### DIFF
--- a/wagon-providers/pom.xml
+++ b/wagon-providers/pom.xml
@@ -64,15 +64,18 @@ under the License.
       <groupId>org.apache.maven.wagon</groupId>
       <artifactId>wagon-provider-api</artifactId>
     </dependency>
+    <!-- @Named and @Typed are runtime-retained, but every container that loads a wagon
+         already supplies them, so they stay off the transitive classpath. -->
     <dependency>
       <groupId>javax.inject</groupId>
       <artifactId>javax.inject</artifactId>
       <version>1</version>
+      <scope>provided</scope>
     </dependency>
-    <!-- for @Typed, where a provider implements more roles than it is published under -->
     <dependency>
       <groupId>org.eclipse.sisu</groupId>
       <artifactId>org.eclipse.sisu.inject</artifactId>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.maven.wagon</groupId>


### PR DESCRIPTION
Ports #986 to `master`, which carries the same compile scopes.

The JSR-330 migration added `javax.inject` and `org.eclipse.sisu.inject` to `wagon-providers/pom.xml` at compile scope, so every consumer of a provider inherits them. Scoping both `provided` keeps them on the compile and test classpaths, and off the transitive one.

Any container that can load a wagon supplies both already. Wagon resolves sisu through maven-parent 49 at 1.0.1 while Maven ships 1.1.0, so the inherited copy was only ever a version to resolve away.

`dependency:tree` for a project depending on `wagon-file` and `wagon-webdav-jackrabbit` carries no `sisu`, `javax.inject` or `guice` entry after this change.

The commit is a clean cherry-pick of cea03168.

Verified: `mvn clean install` with `wagon-ssh-external` excluded -> BUILD SUCCESS. Two suites do not pass in my environment and fail identically on stock `master`, so they are untouched by this change:

- `wagon-ssh-external` reports 57 tests, 3 failures, 21 errors both with and without the commit (`ssh: connect to host localhost` exit 255; no local sshd).
- `HugeFileDownloadTest` needs about 4 GB of scratch space for a 2 GB fixture, and my disk had 1.4 GB free. The 3.x line halved that fixture in 3fca786f; `master` has no equivalent commit, so this test is heavier here.

Both run in CI, which is the gate for them.

*This change was created with AI assistance.*
