### PR TITLE
Migrate the site descriptor to the v2 model

### DIFF
--- a/src/site/site.xml
+++ b/src/site/site.xml
@@ -19,9 +19,9 @@ specific language governing permissions and limitations
 under the License.
 -->
 
-<project xmlns="http://maven.apache.org/DECORATION/1.8.0"
+<site xmlns="http://maven.apache.org/SITE/2.1.0"
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://maven.apache.org/DECORATION/1.8.0 http://maven.apache.org/xsd/decoration-1.8.0.xsd"
+  xsi:schemaLocation="http://maven.apache.org/SITE/2.1.0 https://maven.apache.org/xsd/site-2.1.0.xsd"
   name="Apache Maven Wagon">
 
   <body>
@@ -41,4 +41,4 @@ under the License.
     <menu ref="modules" />
     <menu ref="reports" />
   </body>
-</project>
+</site>

--- a/wagon-provider-api/src/site/site.xml
+++ b/wagon-provider-api/src/site/site.xml
@@ -19,9 +19,9 @@ specific language governing permissions and limitations
 under the License.
 -->
 
-<project xmlns="http://maven.apache.org/DECORATION/1.3.0"
+<site xmlns="http://maven.apache.org/SITE/2.1.0"
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://maven.apache.org/DECORATION/1.3.0 http://maven.apache.org/xsd/decoration-1.3.0.xsd">
+  xsi:schemaLocation="http://maven.apache.org/SITE/2.1.0 https://maven.apache.org/xsd/site-2.1.0.xsd">
   <body>
     <breadcrumbs>
       <item name="API" href="./index.html" />
@@ -35,4 +35,4 @@ under the License.
     <menu ref="parent"/>
     <menu ref="reports"/>
   </body>
-</project>
+</site>

--- a/wagon-provider-test/src/site/site.xml
+++ b/wagon-provider-test/src/site/site.xml
@@ -19,9 +19,9 @@ specific language governing permissions and limitations
 under the License.
 -->
 
-<project xmlns="http://maven.apache.org/DECORATION/1.3.0"
+<site xmlns="http://maven.apache.org/SITE/2.1.0"
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://maven.apache.org/DECORATION/1.3.0 http://maven.apache.org/xsd/decoration-1.3.0.xsd">
+  xsi:schemaLocation="http://maven.apache.org/SITE/2.1.0 https://maven.apache.org/xsd/site-2.1.0.xsd">
   <body>
     <breadcrumbs>
       <item name="Provider Test" href="./index.html" />
@@ -30,4 +30,4 @@ under the License.
     <menu ref="parent"/>
     <menu ref="reports"/>
   </body>
-</project>
+</site>

--- a/wagon-providers/src/site/site.xml
+++ b/wagon-providers/src/site/site.xml
@@ -19,9 +19,9 @@ specific language governing permissions and limitations
 under the License.
 -->
 
-<project xmlns="http://maven.apache.org/DECORATION/1.3.0"
+<site xmlns="http://maven.apache.org/SITE/2.1.0"
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://maven.apache.org/DECORATION/1.3.0 http://maven.apache.org/xsd/decoration-1.3.0.xsd">
+  xsi:schemaLocation="http://maven.apache.org/SITE/2.1.0 https://maven.apache.org/xsd/site-2.1.0.xsd">
   <body>
     <breadcrumbs>
       <item name="Providers" href="./index.html" />
@@ -31,4 +31,4 @@ under the License.
     <menu ref="modules"/>
     <menu ref="reports"/>
   </body>
-</project>
+</site>

--- a/wagon-providers/wagon-file/src/site/site.xml
+++ b/wagon-providers/wagon-file/src/site/site.xml
@@ -19,9 +19,9 @@ specific language governing permissions and limitations
 under the License.
 -->
 
-<project xmlns="http://maven.apache.org/DECORATION/1.3.0"
+<site xmlns="http://maven.apache.org/SITE/2.1.0"
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://maven.apache.org/DECORATION/1.3.0 http://maven.apache.org/xsd/decoration-1.3.0.xsd">
+  xsi:schemaLocation="http://maven.apache.org/SITE/2.1.0 https://maven.apache.org/xsd/site-2.1.0.xsd">
   <body>
     <breadcrumbs>
       <item name="File" href="./index.html" />
@@ -30,4 +30,4 @@ under the License.
     <menu ref="parent"/>
     <menu ref="reports"/>
   </body>
-</project>
+</site>

--- a/wagon-providers/wagon-ftp/src/site/site.xml
+++ b/wagon-providers/wagon-ftp/src/site/site.xml
@@ -19,9 +19,9 @@ specific language governing permissions and limitations
 under the License.
 -->
 
-<project xmlns="http://maven.apache.org/DECORATION/1.3.0"
+<site xmlns="http://maven.apache.org/SITE/2.1.0"
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://maven.apache.org/DECORATION/1.3.0 http://maven.apache.org/xsd/decoration-1.3.0.xsd">
+  xsi:schemaLocation="http://maven.apache.org/SITE/2.1.0 https://maven.apache.org/xsd/site-2.1.0.xsd">
   <body>
     <breadcrumbs>
       <item name="FTP" href="./index.html" />
@@ -30,4 +30,4 @@ under the License.
     <menu ref="parent"/>
     <menu ref="reports"/>
   </body>
-</project>
+</site>

--- a/wagon-providers/wagon-http-lightweight/src/site/site.xml
+++ b/wagon-providers/wagon-http-lightweight/src/site/site.xml
@@ -19,9 +19,9 @@ specific language governing permissions and limitations
 under the License.
 -->
 
-<project xmlns="http://maven.apache.org/DECORATION/1.3.0"
+<site xmlns="http://maven.apache.org/SITE/2.1.0"
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://maven.apache.org/DECORATION/1.3.0 http://maven.apache.org/xsd/decoration-1.3.0.xsd">
+  xsi:schemaLocation="http://maven.apache.org/SITE/2.1.0 https://maven.apache.org/xsd/site-2.1.0.xsd">
   <body>
     <breadcrumbs>
       <item name="Lightweight HTTP" href="./index.html" />
@@ -30,4 +30,4 @@ under the License.
     <menu ref="parent"/>
     <menu ref="reports"/>
   </body>
-</project>
+</site>

--- a/wagon-providers/wagon-http-shared/src/site/site.xml
+++ b/wagon-providers/wagon-http-shared/src/site/site.xml
@@ -19,9 +19,9 @@ specific language governing permissions and limitations
 under the License.
 -->
 
-<project xmlns="http://maven.apache.org/DECORATION/1.3.0"
+<site xmlns="http://maven.apache.org/SITE/2.1.0"
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://maven.apache.org/DECORATION/1.3.0 http://maven.apache.org/xsd/decoration-1.3.0.xsd">
+  xsi:schemaLocation="http://maven.apache.org/SITE/2.1.0 https://maven.apache.org/xsd/site-2.1.0.xsd">
   <body>
     <breadcrumbs>
       <item name="HTTP Shared" href="./index.html" />
@@ -30,4 +30,4 @@ under the License.
     <menu ref="parent"/>
     <menu ref="reports"/>
   </body>
-</project>
+</site>

--- a/wagon-providers/wagon-http/src/site/site.xml
+++ b/wagon-providers/wagon-http/src/site/site.xml
@@ -19,9 +19,9 @@ specific language governing permissions and limitations
 under the License.
 -->
 
-<project xmlns="http://maven.apache.org/DECORATION/1.3.0"
+<site xmlns="http://maven.apache.org/SITE/2.1.0"
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://maven.apache.org/DECORATION/1.3.0 http://maven.apache.org/xsd/decoration-1.3.0.xsd">
+  xsi:schemaLocation="http://maven.apache.org/SITE/2.1.0 https://maven.apache.org/xsd/site-2.1.0.xsd">
   <body>
     <breadcrumbs>
       <item name="HTTP" href="./index.html" />
@@ -30,4 +30,4 @@ under the License.
     <menu ref="parent"/>
     <menu ref="reports"/>
   </body>
-</project>
+</site>

--- a/wagon-providers/wagon-scm/src/site/site.xml
+++ b/wagon-providers/wagon-scm/src/site/site.xml
@@ -19,9 +19,9 @@ specific language governing permissions and limitations
 under the License.
 -->
 
-<project xmlns="http://maven.apache.org/DECORATION/1.3.0"
+<site xmlns="http://maven.apache.org/SITE/2.1.0"
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://maven.apache.org/DECORATION/1.3.0 http://maven.apache.org/xsd/decoration-1.3.0.xsd">
+  xsi:schemaLocation="http://maven.apache.org/SITE/2.1.0 https://maven.apache.org/xsd/site-2.1.0.xsd">
   <body>
     <breadcrumbs>
       <item name="SCM" href="./index.html" />
@@ -34,4 +34,4 @@ under the License.
     </menu>
     <menu ref="reports"/>
   </body>
-</project>
+</site>

--- a/wagon-providers/wagon-ssh-common-test/src/site/site.xml
+++ b/wagon-providers/wagon-ssh-common-test/src/site/site.xml
@@ -19,9 +19,9 @@ specific language governing permissions and limitations
 under the License.
 -->
 
-<project xmlns="http://maven.apache.org/DECORATION/1.3.0"
+<site xmlns="http://maven.apache.org/SITE/2.1.0"
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://maven.apache.org/DECORATION/1.3.0 http://maven.apache.org/xsd/decoration-1.3.0.xsd">
+  xsi:schemaLocation="http://maven.apache.org/SITE/2.1.0 https://maven.apache.org/xsd/site-2.1.0.xsd">
   <body>
     <breadcrumbs>
       <item name="SSH Common Test" href="./index.html" />
@@ -30,4 +30,4 @@ under the License.
     <menu ref="parent"/>
     <menu ref="reports"/>
   </body>
-</project>
+</site>

--- a/wagon-providers/wagon-ssh-common/src/site/site.xml
+++ b/wagon-providers/wagon-ssh-common/src/site/site.xml
@@ -19,9 +19,9 @@ specific language governing permissions and limitations
 under the License.
 -->
 
-<project xmlns="http://maven.apache.org/DECORATION/1.3.0"
+<site xmlns="http://maven.apache.org/SITE/2.1.0"
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://maven.apache.org/DECORATION/1.3.0 http://maven.apache.org/xsd/decoration-1.3.0.xsd">
+  xsi:schemaLocation="http://maven.apache.org/SITE/2.1.0 https://maven.apache.org/xsd/site-2.1.0.xsd">
   <body>
     <breadcrumbs>
       <item name="SSH Common" href="./index.html" />
@@ -30,4 +30,4 @@ under the License.
     <menu ref="parent"/>
     <menu ref="reports"/>
   </body>
-</project>
+</site>

--- a/wagon-providers/wagon-ssh-external/src/site/site.xml
+++ b/wagon-providers/wagon-ssh-external/src/site/site.xml
@@ -19,9 +19,9 @@ specific language governing permissions and limitations
 under the License.
 -->
 
-<project xmlns="http://maven.apache.org/DECORATION/1.3.0"
+<site xmlns="http://maven.apache.org/SITE/2.1.0"
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://maven.apache.org/DECORATION/1.3.0 http://maven.apache.org/xsd/decoration-1.3.0.xsd">
+  xsi:schemaLocation="http://maven.apache.org/SITE/2.1.0 https://maven.apache.org/xsd/site-2.1.0.xsd">
   <body>
     <breadcrumbs>
       <item name="SSH External" href="./index.html" />
@@ -30,4 +30,4 @@ under the License.
     <menu ref="parent"/>
     <menu ref="reports"/>
   </body>
-</project>
+</site>

--- a/wagon-providers/wagon-ssh/src/site/site.xml
+++ b/wagon-providers/wagon-ssh/src/site/site.xml
@@ -19,9 +19,9 @@ specific language governing permissions and limitations
 under the License.
 -->
 
-<project xmlns="http://maven.apache.org/DECORATION/1.3.0"
+<site xmlns="http://maven.apache.org/SITE/2.1.0"
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://maven.apache.org/DECORATION/1.3.0 http://maven.apache.org/xsd/decoration-1.3.0.xsd">
+  xsi:schemaLocation="http://maven.apache.org/SITE/2.1.0 https://maven.apache.org/xsd/site-2.1.0.xsd">
   <body>
     <breadcrumbs>
       <item name="SSH" href="./index.html" />
@@ -30,4 +30,4 @@ under the License.
     <menu ref="parent"/>
     <menu ref="reports"/>
   </body>
-</project>
+</site>

--- a/wagon-providers/wagon-webdav-jackrabbit/src/site/site.xml
+++ b/wagon-providers/wagon-webdav-jackrabbit/src/site/site.xml
@@ -19,9 +19,9 @@ specific language governing permissions and limitations
 under the License.
 -->
 
-<project xmlns="http://maven.apache.org/DECORATION/1.3.0"
+<site xmlns="http://maven.apache.org/SITE/2.1.0"
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://maven.apache.org/DECORATION/1.3.0 http://maven.apache.org/xsd/decoration-1.3.0.xsd">
+  xsi:schemaLocation="http://maven.apache.org/SITE/2.1.0 https://maven.apache.org/xsd/site-2.1.0.xsd">
   <body>
     <breadcrumbs>
       <item name="WebDAV Jackrabbit" href="./index.html" />
@@ -30,4 +30,4 @@ under the License.
     <menu ref="parent"/>
     <menu ref="reports"/>
   </body>
-</project>
+</site>

--- a/wagon-tcks/src/site/site.xml
+++ b/wagon-tcks/src/site/site.xml
@@ -19,9 +19,9 @@ specific language governing permissions and limitations
 under the License.
 -->
 
-<project xmlns="http://maven.apache.org/DECORATION/1.3.0"
+<site xmlns="http://maven.apache.org/SITE/2.1.0"
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://maven.apache.org/DECORATION/1.3.0 http://maven.apache.org/xsd/decoration-1.3.0.xsd">
+  xsi:schemaLocation="http://maven.apache.org/SITE/2.1.0 https://maven.apache.org/xsd/site-2.1.0.xsd">
   <body>
     <breadcrumbs>
       <item name="TCKs" href="./index.html" />
@@ -31,4 +31,4 @@ under the License.
     <menu ref="modules"/>
     <menu ref="reports"/>
   </body>
-</project>
+</site>

--- a/wagon-tcks/wagon-tck-http/src/site/site.xml
+++ b/wagon-tcks/wagon-tck-http/src/site/site.xml
@@ -19,9 +19,9 @@ specific language governing permissions and limitations
 under the License.
 -->
 
-<project xmlns="http://maven.apache.org/DECORATION/1.3.0"
+<site xmlns="http://maven.apache.org/SITE/2.1.0"
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://maven.apache.org/DECORATION/1.3.0 http://maven.apache.org/xsd/decoration-1.3.0.xsd">
+  xsi:schemaLocation="http://maven.apache.org/SITE/2.1.0 https://maven.apache.org/xsd/site-2.1.0.xsd">
   <body>
     <breadcrumbs>
       <item name="HTTP" href="./index.html" />
@@ -30,4 +30,4 @@ under the License.
     <menu ref="parent"/>
     <menu ref="reports"/>
   </body>
-</project>
+</site>


### PR DESCRIPTION
Converts all 17 `src/site/site.xml` descriptors still on the DECORATION namespace (root project plus wagon-provider-api, wagon-provider-test, wagon-providers and its 11 submodules, and wagon-tcks and wagon-tck-http) to the v2 site model: only the root element, namespace, and `xsi:schemaLocation` change, from `<project xmlns=".../DECORATION/x.y.z">` to `<site xmlns="http://maven.apache.org/SITE/2.1.0">`. Doxia Sitetools currently warns on every build: "Site model of '<gav>' for default locale is still using the old pre-version 2.0.0 model. You MUST migrate to the new model as soon as possible otherwise your build will break in the future!" Verified: every converted file validates against site-2.1.0.xsd via `xmllint`, and `mvn -B -N site -DskipTests` at the root and `mvn -B site -DskipTests` in wagon-provider-api both end BUILD SUCCESS with the warning gone from the log; the remaining modules were not built (a full multi-module site build was not run).

*This change was created with AI assistance.*
